### PR TITLE
refactor: `ApiResponse`,`ErrorResponse` 의 상태코드 필드명 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.5'
 }
 
-group = 'com.example'
+group = 'com.odiga'
 version = '0.0.1-SNAPSHOT'
 
 java {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'demo'
+rootProject.name = 'fiesta'

--- a/src/main/java/com/example/demo/common/aop/A.java
+++ b/src/main/java/com/example/demo/common/aop/A.java
@@ -1,4 +1,0 @@
-package com.example.demo.common.aop;
-
-public class A {
-}

--- a/src/main/java/com/example/demo/common/jwt/J.java
+++ b/src/main/java/com/example/demo/common/jwt/J.java
@@ -1,4 +1,0 @@
-package com.example.demo.common.jwt;
-
-public class J {
-}

--- a/src/main/java/com/example/demo/common/util/U.java
+++ b/src/main/java/com/example/demo/common/util/U.java
@@ -1,4 +1,0 @@
-package com.example.demo.common.util;
-
-public class U {
-}

--- a/src/main/java/com/odiga/fiesta/DemoApplication.java
+++ b/src/main/java/com/odiga/fiesta/DemoApplication.java
@@ -1,4 +1,4 @@
-package com.example.demo;
+package com.odiga.fiesta;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/odiga/fiesta/common/ApiResponse.java
+++ b/src/main/java/com/odiga/fiesta/common/ApiResponse.java
@@ -11,14 +11,14 @@ import lombok.Getter;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
-	private int code;
-	private HttpStatus status;
+	private int statusCode;
+	private HttpStatus status; // reason phrase
 	private String message;
 	private T data;
 
 	@Builder
 	private ApiResponse(HttpStatus status, String message, T data) {
-		this.code = status.value();
+		this.statusCode = status.value();
 		this.status = status;
 		this.message = message;
 		this.data = data;

--- a/src/main/java/com/odiga/fiesta/common/ApiResponse.java
+++ b/src/main/java/com/odiga/fiesta/common/ApiResponse.java
@@ -1,4 +1,4 @@
-package com.example.demo.common;
+package com.odiga.fiesta.common;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/odiga/fiesta/common/aop/A.java
+++ b/src/main/java/com/odiga/fiesta/common/aop/A.java
@@ -1,0 +1,4 @@
+package com.odiga.fiesta.common.aop;
+
+public class A {
+}

--- a/src/main/java/com/odiga/fiesta/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/odiga/fiesta/common/config/JpaAuditingConfig.java
@@ -1,4 +1,4 @@
-package com.example.demo.common.config;
+package com.odiga.fiesta.common.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;

--- a/src/main/java/com/odiga/fiesta/common/domain/BaseEntity.java
+++ b/src/main/java/com/odiga/fiesta/common/domain/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.example.demo.common.domain;
+package com.odiga.fiesta.common.domain;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/odiga/fiesta/common/error/ErrorCode.java
+++ b/src/main/java/com/odiga/fiesta/common/error/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.example.demo.common.error;
+package com.odiga.fiesta.common.error;
 
 import java.util.Collections;
 import java.util.Map;

--- a/src/main/java/com/odiga/fiesta/common/error/ErrorResponse.java
+++ b/src/main/java/com/odiga/fiesta/common/error/ErrorResponse.java
@@ -9,28 +9,28 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorResponse {
 
-	private int status;
-	private String code;
+	private int statusCode; // http 상태코드
+	private String code; // 커스텀 에러 코드
 	private String message;
 
 	@Builder
-	private ErrorResponse(int status, String code, String message) {
-		this.status = status;
+	private ErrorResponse(int statusCode, String code, String message) {
+		this.statusCode = statusCode;
 		this.code = code;
 		this.message = message;
 	}
 
 	public static ErrorResponse of(ErrorCode errorCode) {
 		return ErrorResponse.builder()
-			.status(errorCode.getStatus())
+			.statusCode(errorCode.getStatus())
 			.code(errorCode.getCode())
 			.message(errorCode.getMessage())
 			.build();
 	}
 
-	public static ErrorResponse of(int status, String code, String message) {
+	public static ErrorResponse of(int statusCode, String code, String message) {
 		return ErrorResponse.builder()
-			.status(status)
+			.statusCode(statusCode)
 			.code(code)
 			.message(message)
 			.build();

--- a/src/main/java/com/odiga/fiesta/common/error/ErrorResponse.java
+++ b/src/main/java/com/odiga/fiesta/common/error/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.example.demo.common.error;
+package com.odiga.fiesta.common.error;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/odiga/fiesta/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/odiga/fiesta/common/error/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.example.demo.common.error;
+package com.odiga.fiesta.common.error;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;

--- a/src/main/java/com/odiga/fiesta/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/odiga/fiesta/common/error/GlobalExceptionHandler.java
@@ -22,7 +22,7 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorResponse> handleServerException(Exception e) {
 		log.warn(e.getMessage(), e);
 		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
-		return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
+		return ResponseEntity.status(errorResponse.getStatusCode()).body(errorResponse);
 	}
 
 	// 405 : Method Not Allowed
@@ -31,7 +31,7 @@ public class GlobalExceptionHandler {
 		HttpRequestMethodNotSupportedException e) {
 		log.error(e.getMessage(), e);
 		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
-		return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
+		return ResponseEntity.status(errorResponse.getStatusCode()).body(errorResponse);
 	}
 
 	// 400 : MethodArgumentNotValidException
@@ -40,7 +40,7 @@ public class GlobalExceptionHandler {
 		MethodArgumentNotValidException e) {
 		log.warn(e.getMessage(), e);
 		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
-		return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
+		return ResponseEntity.status(errorResponse.getStatusCode()).body(errorResponse);
 	}
 
 	// 400 : MethodArgumentType
@@ -49,7 +49,7 @@ public class GlobalExceptionHandler {
 		MethodArgumentTypeMismatchException e) {
 		log.error(e.getMessage(), e);
 		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_TYPE_VALUE);
-		return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
+		return ResponseEntity.status(errorResponse.getStatusCode()).body(errorResponse);
 	}
 
 	// 400 : Bad Request, ModelAttribute
@@ -57,7 +57,7 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorResponse> handleBindException(BindException e) {
 		log.warn(e.getMessage(), e);
 		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
-		return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
+		return ResponseEntity.status(errorResponse.getStatusCode()).body(errorResponse);
 	}
 
 	@ExceptionHandler(HttpMessageNotReadableException.class)
@@ -65,21 +65,21 @@ public class GlobalExceptionHandler {
 		HttpMessageNotReadableException e) {
 		log.warn(e.getMessage(), e);
 		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
-		return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
+		return ResponseEntity.status(errorResponse.getStatusCode()).body(errorResponse);
 	}
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
 		log.warn(e.getMessage(), e);
 		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
-		return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
+		return ResponseEntity.status(errorResponse.getStatusCode()).body(errorResponse);
 	}
 
 	@ExceptionHandler(NoHandlerFoundException.class)
 	public ResponseEntity<ErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException e) {
 		log.warn(e.getMessage(), e);
 		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.NOT_FOUND);
-		return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
+		return ResponseEntity.status(errorResponse.getStatusCode()).body(errorResponse);
 	}
 
 	@ExceptionHandler(MissingServletRequestParameterException.class)
@@ -87,6 +87,6 @@ public class GlobalExceptionHandler {
 		MissingServletRequestParameterException e) {
 		log.warn(e.getMessage(), e);
 		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.MISSING_REQUEST_PARAMETER);
-		return ResponseEntity.status(errorResponse.getStatus()).body(errorResponse);
+		return ResponseEntity.status(errorResponse.getStatusCode()).body(errorResponse);
 	}
 }

--- a/src/main/java/com/odiga/fiesta/common/error/exception/CustomException.java
+++ b/src/main/java/com/odiga/fiesta/common/error/exception/CustomException.java
@@ -1,6 +1,6 @@
-package com.example.demo.common.error.exception;
+package com.odiga.fiesta.common.error.exception;
 
-import com.example.demo.common.error.ErrorCode;
+import com.odiga.fiesta.common.error.ErrorCode;
 
 import lombok.Getter;
 

--- a/src/main/java/com/odiga/fiesta/common/jwt/J.java
+++ b/src/main/java/com/odiga/fiesta/common/jwt/J.java
@@ -1,0 +1,4 @@
+package com.odiga.fiesta.common.jwt;
+
+public class J {
+}

--- a/src/main/java/com/odiga/fiesta/common/util/U.java
+++ b/src/main/java/com/odiga/fiesta/common/util/U.java
@@ -1,0 +1,4 @@
+package com.odiga.fiesta.common.util;
+
+public class U {
+}

--- a/src/main/java/com/odiga/fiesta/hello/controller/HelloController.java
+++ b/src/main/java/com/odiga/fiesta/hello/controller/HelloController.java
@@ -1,10 +1,10 @@
-package com.example.demo.hello.controller;
+package com.odiga.fiesta.hello.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.example.demo.common.ApiResponse;
+import com.odiga.fiesta.common.ApiResponse;
 
 @RestController
 public class HelloController {

--- a/src/test/java/com/odiga/fiesta/ControllerTestSupport.java
+++ b/src/test/java/com/odiga/fiesta/ControllerTestSupport.java
@@ -1,10 +1,10 @@
-package com.example.demo;
+package com.odiga.fiesta;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.example.demo.hello.controller.HelloController;
+import com.odiga.fiesta.hello.controller.HelloController;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(controllers = {

--- a/src/test/java/com/odiga/fiesta/DemoApplicationTests.java
+++ b/src/test/java/com/odiga/fiesta/DemoApplicationTests.java
@@ -1,4 +1,4 @@
-package com.example.demo;
+package com.odiga.fiesta;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/com/odiga/fiesta/hello/controller/HelloControllerTest.java
+++ b/src/test/java/com/odiga/fiesta/hello/controller/HelloControllerTest.java
@@ -1,4 +1,4 @@
-package com.example.demo.hello.controller;
+package com.odiga.fiesta.hello.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -7,7 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import com.example.demo.ControllerTestSupport;
+import com.odiga.fiesta.ControllerTestSupport;
 
 class HelloControllerTest extends ControllerTestSupport {
 

--- a/src/test/java/com/odiga/fiesta/hello/controller/HelloControllerTest.java
+++ b/src/test/java/com/odiga/fiesta/hello/controller/HelloControllerTest.java
@@ -22,7 +22,7 @@ class HelloControllerTest extends ControllerTestSupport {
 			)
 			.andDo(print())
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value(200))
+			.andExpect(jsonPath("$.statusCode").value(200))
 			.andExpect(jsonPath("$.status").value("OK"))
 			.andExpect(jsonPath("$.message").value("API 응답 테스트"))
 			.andExpect(jsonPath("$.data").isString());


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약

기본 응답 형태 fe 의견 반영 

- **기본 응답**

```json
{
  "statusCode": 200,
  "status": "OK",
  "message": "축제 조회 성공",
  "data": {
  }
}
```

- **에러 응답**

```json
{
  "statusCode": 500,
  "code": "S001",
  "message": "서버에 문제가 생겼습니다."
}
```

# 작업 내용

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [x] [refactor: ApiResponse,ErrorResponse 의 상태코드 필드명 변경](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/db95ec30600c41181db981e128703141bbc72205)


# 기타 (논의하고 싶은 부분)

# 타 직군 전달 사항

close #3
