### PR TITLE
feat: 페스티벌 정적 데이터 관련 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,7 @@ jacocoTestReport {
                             '**/dto/**',
                             '**/common/**',
                             "**/repository/*",
+                            "**/domain/**"
                     ])
                 })
         )
@@ -145,7 +146,8 @@ jacocoTestCoverageVerification {
                     '*.*Application',
                     '*.dto.*',
                     '*.common.*',
-                    '*.repository.*'
+                    '*.repository.*',
+                    "*.domain.*"
             ] + Qdomains
         }
     }

--- a/src/main/java/com/odiga/fiesta/common/BasicResponse.java
+++ b/src/main/java/com/odiga/fiesta/common/BasicResponse.java
@@ -9,38 +9,38 @@ import lombok.Getter;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ApiResponse<T> {
+public class BasicResponse<T> {
 
 	private final int statusCode;
-	private final HttpStatus status; // reason phrase
+	private final String status; // reason phrase
 	private final String message;
 	private final T data;
 
 	@Builder
-	private ApiResponse(HttpStatus status, String message, T data) {
+	private BasicResponse(HttpStatus status, String message, T data) {
 		this.statusCode = status.value();
-		this.status = status;
+		this.status = status.getReasonPhrase();
 		this.message = message;
 		this.data = data;
 	}
 
-	public static <T> ApiResponse<T> of(HttpStatus status, String message, T data) {
-		return ApiResponse.<T>builder()
+	public static <T> BasicResponse<T> of(HttpStatus status, String message, T data) {
+		return BasicResponse.<T>builder()
 			.status(status)
 			.message(message)
 			.data(data)
 			.build();
 	}
 
-	public static <T> ApiResponse<T> of(HttpStatus status, T data) {
+	public static <T> BasicResponse<T> of(HttpStatus status, T data) {
 		return of(status, status.name(), data);
 	}
 
-	public static <T> ApiResponse<T> ok(T data) {
+	public static <T> BasicResponse<T> ok(T data) {
 		return of(HttpStatus.OK, data);
 	}
 
-	public static <T> ApiResponse<T> ok(String message, T data) {
+	public static <T> BasicResponse<T> ok(String message, T data) {
 		return of(HttpStatus.OK, message, data);
 	}
 }

--- a/src/main/java/com/odiga/fiesta/festival/controller/FestivalController.java
+++ b/src/main/java/com/odiga/fiesta/festival/controller/FestivalController.java
@@ -1,0 +1,78 @@
+package com.odiga.fiesta.festival.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.odiga.fiesta.common.BasicResponse;
+import com.odiga.fiesta.festival.dto.response.CategoryResponse;
+import com.odiga.fiesta.festival.dto.response.CompanionResponse;
+import com.odiga.fiesta.festival.dto.response.MoodResponse;
+import com.odiga.fiesta.festival.dto.response.PriorityResponse;
+import com.odiga.fiesta.festival.service.CategoryService;
+import com.odiga.fiesta.festival.service.CompanionService;
+import com.odiga.fiesta.festival.service.MoodService;
+import com.odiga.fiesta.festival.service.PriorityService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Festival", description = "페스티벌 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/festivals")
+public class FestivalController {
+
+	private final MoodService moodService;
+	private final CategoryService categoryService;
+	private final CompanionService companionService;
+	private final PriorityService priorityService;
+
+	@Operation(
+		summary = "모든 페스티벌 분위기 타입 조회",
+		description = "페스티벌 분위기 타입들을 조회합니다."
+	)
+	@GetMapping("/moods")
+	public ResponseEntity<BasicResponse<List<MoodResponse>>> getAllMoods() {
+		final BasicResponse<List<MoodResponse>> moodResponses = BasicResponse.ok(
+			"페스티벌 분위기 조회 성공", moodService.getAllMoods());
+		return ResponseEntity.ok(moodResponses);
+	}
+
+	@Operation(
+		summary = "모든 페스티벌 분류 조회",
+		description = "페스티벌 분류들을 조회합니다."
+	)
+	@GetMapping("/categories")
+	public ResponseEntity<BasicResponse<List<CategoryResponse>>> getCategories() {
+		final BasicResponse<List<CategoryResponse>> categoryResponses = BasicResponse.ok(
+			"페스티벌 카테고리 조회 성공", categoryService.getAllCategories());
+		return ResponseEntity.ok(categoryResponses);
+	}
+
+	@Operation(
+		summary = "모든 일행 분류 조회",
+		description = "일행 분류들을 조회합니다."
+	)
+	@GetMapping("/companions")
+	public ResponseEntity<BasicResponse<List<CompanionResponse>>> getCompanions() {
+		final BasicResponse<List<CompanionResponse>> companionResponses = BasicResponse.ok(
+			"페스티벌 일행 분류 조회 성공", companionService.getAllCompanions());
+		return ResponseEntity.ok(companionResponses);
+	}
+
+	@Operation(
+		summary = "모든 페스티벌 우선순위 분류 조회",
+		description = "페스티벌 우선순위 분류들을 조회합니다."
+	)
+	@GetMapping("/priorities")
+	public ResponseEntity<BasicResponse<List<PriorityResponse>>> getPriorities() {
+		final BasicResponse<List<PriorityResponse>> priorityResponses = BasicResponse.ok(
+			"페스티벌 우선순위 조회 성공", priorityService.getAllPriorities());
+		return ResponseEntity.ok(priorityResponses);
+	}
+}

--- a/src/main/java/com/odiga/fiesta/festival/domain/Category.java
+++ b/src/main/java/com/odiga/fiesta/festival/domain/Category.java
@@ -1,0 +1,32 @@
+package com.odiga.fiesta.festival.domain;
+
+import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Category {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "category_id")
+	private Long id;
+
+	@Column(nullable = false)
+	private String category;
+
+	@Builder
+	public Category(Long id, String category) {
+		this.id = id;
+		this.category = category;
+	}
+}

--- a/src/main/java/com/odiga/fiesta/festival/domain/Companion.java
+++ b/src/main/java/com/odiga/fiesta/festival/domain/Companion.java
@@ -1,0 +1,32 @@
+package com.odiga.fiesta.festival.domain;
+
+import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Companion {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "companion_type_id")
+	private Long id;
+
+	@Column(name = "companion_type", nullable = false)
+	private String companionType;
+
+	@Builder
+	public Companion(Long id, String companionType) {
+		this.id = id;
+		this.companionType = companionType;
+	}
+}

--- a/src/main/java/com/odiga/fiesta/festival/domain/Mood.java
+++ b/src/main/java/com/odiga/fiesta/festival/domain/Mood.java
@@ -1,0 +1,32 @@
+package com.odiga.fiesta.festival.domain;
+
+import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Mood {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "mood_id")
+	private Long id;
+
+	@Column(nullable = false)
+	private String mood;
+
+	@Builder
+	public Mood(Long id, String mood) {
+		this.id = id;
+		this.mood = mood;
+	}
+}

--- a/src/main/java/com/odiga/fiesta/festival/domain/Priority.java
+++ b/src/main/java/com/odiga/fiesta/festival/domain/Priority.java
@@ -1,0 +1,32 @@
+package com.odiga.fiesta.festival.domain;
+
+import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Priority {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "priority_id")
+	private Long id;
+
+	@Column(nullable = false)
+	private String priority;
+
+	@Builder
+	public Priority(Long id, String priority) {
+		this.id = id;
+		this.priority = priority;
+	}
+}

--- a/src/main/java/com/odiga/fiesta/festival/dto/response/CategoryResponse.java
+++ b/src/main/java/com/odiga/fiesta/festival/dto/response/CategoryResponse.java
@@ -1,0 +1,23 @@
+package com.odiga.fiesta.festival.dto.response;
+
+import static lombok.AccessLevel.*;
+
+import com.odiga.fiesta.festival.domain.Category;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = PRIVATE)
+public class CategoryResponse {
+
+	private final Long categoryId;
+	private final String category;
+
+	public static CategoryResponse of(final Category category) {
+		return new CategoryResponse(
+			category.getId(),
+			category.getCategory()
+		);
+	}
+}

--- a/src/main/java/com/odiga/fiesta/festival/dto/response/CompanionResponse.java
+++ b/src/main/java/com/odiga/fiesta/festival/dto/response/CompanionResponse.java
@@ -1,0 +1,23 @@
+package com.odiga.fiesta.festival.dto.response;
+
+import static lombok.AccessLevel.*;
+
+import com.odiga.fiesta.festival.domain.Companion;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = PRIVATE)
+public class CompanionResponse {
+
+	private final Long companionId;
+	private final String companionType;
+
+	public static CompanionResponse of(final Companion companion) {
+		return new CompanionResponse(
+			companion.getId(),
+			companion.getCompanionType()
+		);
+	}
+}

--- a/src/main/java/com/odiga/fiesta/festival/dto/response/MoodResponse.java
+++ b/src/main/java/com/odiga/fiesta/festival/dto/response/MoodResponse.java
@@ -1,0 +1,23 @@
+package com.odiga.fiesta.festival.dto.response;
+
+import static lombok.AccessLevel.*;
+
+import com.odiga.fiesta.festival.domain.Mood;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = PRIVATE)
+public class MoodResponse {
+
+	private final Long moodId;
+	private final String mood;
+
+	public static MoodResponse of(final Mood mood) {
+		return new MoodResponse(
+			mood.getId(),
+			mood.getMood()
+		);
+	}
+}

--- a/src/main/java/com/odiga/fiesta/festival/dto/response/PriorityResponse.java
+++ b/src/main/java/com/odiga/fiesta/festival/dto/response/PriorityResponse.java
@@ -1,0 +1,23 @@
+package com.odiga.fiesta.festival.dto.response;
+
+import static lombok.AccessLevel.*;
+
+import com.odiga.fiesta.festival.domain.Priority;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = PRIVATE)
+public class PriorityResponse {
+
+	private final Long priorityId;
+	private final String priority;
+
+	public static PriorityResponse of(final Priority priority) {
+		return new PriorityResponse(
+			priority.getId(),
+			priority.getPriority()
+		);
+	}
+}

--- a/src/main/java/com/odiga/fiesta/festival/repository/CategoryRepository.java
+++ b/src/main/java/com/odiga/fiesta/festival/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package com.odiga.fiesta.festival.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.odiga.fiesta.festival.domain.Category;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/odiga/fiesta/festival/repository/CompanionRepository.java
+++ b/src/main/java/com/odiga/fiesta/festival/repository/CompanionRepository.java
@@ -1,0 +1,8 @@
+package com.odiga.fiesta.festival.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.odiga.fiesta.festival.domain.Companion;
+
+public interface CompanionRepository extends JpaRepository<Companion, Long> {
+}

--- a/src/main/java/com/odiga/fiesta/festival/repository/MoodRepository.java
+++ b/src/main/java/com/odiga/fiesta/festival/repository/MoodRepository.java
@@ -1,0 +1,8 @@
+package com.odiga.fiesta.festival.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.odiga.fiesta.festival.domain.Mood;
+
+public interface MoodRepository extends JpaRepository<Mood, Long> {
+}

--- a/src/main/java/com/odiga/fiesta/festival/repository/PriorityRepository.java
+++ b/src/main/java/com/odiga/fiesta/festival/repository/PriorityRepository.java
@@ -1,0 +1,8 @@
+package com.odiga.fiesta.festival.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.odiga.fiesta.festival.domain.Priority;
+
+public interface PriorityRepository extends JpaRepository<Priority, Long> {
+}

--- a/src/main/java/com/odiga/fiesta/festival/service/CategoryService.java
+++ b/src/main/java/com/odiga/fiesta/festival/service/CategoryService.java
@@ -1,0 +1,28 @@
+package com.odiga.fiesta.festival.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.odiga.fiesta.festival.domain.Category;
+import com.odiga.fiesta.festival.dto.response.CategoryResponse;
+import com.odiga.fiesta.festival.repository.CategoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryService {
+
+	private final CategoryRepository categoryRepository;
+
+	public List<CategoryResponse> getAllCategories() {
+		final List<Category> categories = categoryRepository.findAll();
+		return categories.stream()
+			.map(CategoryResponse::of)
+			.toList();
+	}
+
+}

--- a/src/main/java/com/odiga/fiesta/festival/service/CompanionService.java
+++ b/src/main/java/com/odiga/fiesta/festival/service/CompanionService.java
@@ -1,0 +1,27 @@
+package com.odiga.fiesta.festival.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.odiga.fiesta.festival.domain.Companion;
+import com.odiga.fiesta.festival.dto.response.CompanionResponse;
+import com.odiga.fiesta.festival.repository.CompanionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CompanionService {
+
+	private final CompanionRepository companionRepository;
+
+	public List<CompanionResponse> getAllCompanions() {
+		final List<Companion> companions = companionRepository.findAll();
+		return companions.stream()
+			.map(CompanionResponse::of)
+			.toList();
+	}
+}

--- a/src/main/java/com/odiga/fiesta/festival/service/MoodService.java
+++ b/src/main/java/com/odiga/fiesta/festival/service/MoodService.java
@@ -1,0 +1,27 @@
+package com.odiga.fiesta.festival.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.odiga.fiesta.festival.domain.Mood;
+import com.odiga.fiesta.festival.dto.response.MoodResponse;
+import com.odiga.fiesta.festival.repository.MoodRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MoodService {
+
+	private final MoodRepository moodRepository;
+
+	public List<MoodResponse> getAllMoods() {
+		final List<Mood> moods = moodRepository.findAll();
+		return moods.stream()
+			.map(MoodResponse::of)
+			.toList();
+	}
+}

--- a/src/main/java/com/odiga/fiesta/festival/service/PriorityService.java
+++ b/src/main/java/com/odiga/fiesta/festival/service/PriorityService.java
@@ -1,0 +1,27 @@
+package com.odiga.fiesta.festival.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.odiga.fiesta.festival.domain.Priority;
+import com.odiga.fiesta.festival.dto.response.PriorityResponse;
+import com.odiga.fiesta.festival.repository.PriorityRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PriorityService {
+
+	private final PriorityRepository priorityRepository;
+
+	public List<PriorityResponse> getAllPriorities() {
+		final List<Priority> priorities = priorityRepository.findAll();
+		return priorities.stream()
+			.map(PriorityResponse::of)
+			.toList();
+	}
+}

--- a/src/main/java/com/odiga/fiesta/hello/controller/HelloController.java
+++ b/src/main/java/com/odiga/fiesta/hello/controller/HelloController.java
@@ -4,14 +4,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.odiga.fiesta.common.ApiResponse;
+import com.odiga.fiesta.common.BasicResponse;
 
 @RestController
 public class HelloController {
 
 	@GetMapping("/hello")
-	public ResponseEntity<ApiResponse<String>> hello() {
-		ApiResponse<String> response = ApiResponse.ok("API 응답 테스트", "Hello, world !");
+	public ResponseEntity<BasicResponse<String>> hello() {
+		BasicResponse<String> response = BasicResponse.ok("API 응답 테스트", "Hello, world !");
 		return ResponseEntity.ok(response);
 	}
 

--- a/src/test/java/com/odiga/fiesta/ControllerTestSupport.java
+++ b/src/test/java/com/odiga/fiesta/ControllerTestSupport.java
@@ -2,17 +2,24 @@ package com.odiga.fiesta;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.odiga.fiesta.hello.controller.HelloController;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.odiga.fiesta.festival.controller.FestivalController;
+import com.odiga.fiesta.festival.service.CategoryService;
+import com.odiga.fiesta.festival.service.CompanionService;
+import com.odiga.fiesta.festival.service.MoodService;
+import com.odiga.fiesta.festival.service.PriorityService;
+import com.odiga.fiesta.hello.controller.HelloController;
 
 @ActiveProfiles("test")
 @WithMockUser
 @WebMvcTest(controllers = {
 	HelloController.class, // 사용하는 컨트롤러 여기에 추가
+	FestivalController.class
 })
 public abstract class ControllerTestSupport {
 	@Autowired
@@ -22,6 +29,15 @@ public abstract class ControllerTestSupport {
 	protected ObjectMapper objectMapper;
 
 	// 모킹할 빈 추가
-	// @MockBean
-	// protected ProductService productService;
+	@MockBean
+	protected CategoryService categoryService;
+
+	@MockBean
+	protected CompanionService companionService;
+
+	@MockBean
+	protected MoodService moodService;
+
+	@MockBean
+	protected PriorityService priorityService;
 }

--- a/src/test/java/com/odiga/fiesta/festival/controller/FestivalControllerTest.java
+++ b/src/test/java/com/odiga/fiesta/festival/controller/FestivalControllerTest.java
@@ -1,0 +1,111 @@
+package com.odiga.fiesta.festival.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.odiga.fiesta.ControllerTestSupport;
+import com.odiga.fiesta.festival.dto.response.CategoryResponse;
+import com.odiga.fiesta.festival.dto.response.CompanionResponse;
+import com.odiga.fiesta.festival.dto.response.MoodResponse;
+import com.odiga.fiesta.festival.dto.response.PriorityResponse;
+import com.odiga.fiesta.festival.service.CategoryService;
+import com.odiga.fiesta.festival.service.CompanionService;
+import com.odiga.fiesta.festival.service.MoodService;
+import com.odiga.fiesta.festival.service.PriorityService;
+
+class FestivalControllerTest extends ControllerTestSupport {
+
+	@Autowired
+	private MoodService moodService;
+
+	@Autowired
+	private CategoryService categoryService;
+
+	@Autowired
+	private CompanionService companionService;
+
+	@Autowired
+	private PriorityService priorityService;
+
+	@DisplayName("모든 페스티벌 분위기를 조회한다.")
+	@Test
+	void getAllMoods() throws Exception {
+		// given
+		String message = "페스티벌 분위기 조회 성공";
+
+		List<MoodResponse> mockMoods = List.of();
+		when(moodService.getAllMoods()).thenReturn(mockMoods);
+
+		// when // then
+		mockMvc.perform(
+				get("/api/v1/festivals/moods")
+			).andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value(message))
+			.andExpect(jsonPath("$.data").isArray());
+	}
+
+	@DisplayName("모든 카테고리를 조회한다.")
+	@Test
+	void getAllCategories() throws Exception {
+		// given
+		String message = "페스티벌 카테고리 조회 성공";
+
+		List<CategoryResponse> mockCategories = List.of();
+		when(categoryService.getAllCategories()).thenReturn(mockCategories);
+
+		// when // then
+		mockMvc.perform(
+				get("/api/v1/festivals/categories")
+			).andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value(message))
+			.andExpect(jsonPath("$.data").isArray());
+
+	}
+
+	@DisplayName("모든 일행 타입을 조회한다.")
+	@Test
+	void getAllCompanions() throws Exception {
+		// given
+		String message = "페스티벌 일행 분류 조회 성공";
+
+		List<CompanionResponse> mockCompanions = List.of();
+		when(companionService.getAllCompanions()).thenReturn(mockCompanions);
+
+		// when // then
+		mockMvc.perform(
+				get("/api/v1/festivals/companions")
+			).andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value(message))
+			.andExpect(jsonPath("$.data").isArray());
+	}
+
+	@DisplayName("모든 페스티벌 우선순위 타입을 조회한다.")
+	@Test
+	void getAllPriorities() throws Exception {
+		// given
+		String message = "페스티벌 우선순위 조회 성공";
+
+		List<PriorityResponse> mockPriorities = List.of();
+		when(priorityService.getAllPriorities()).thenReturn(mockPriorities);
+
+		// when // then
+		mockMvc.perform(
+				get("/api/v1/festivals/priorities")
+			).andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value(message))
+			.andExpect(jsonPath("$.data").isArray());
+	}
+
+}

--- a/src/test/java/com/odiga/fiesta/festival/service/CategoryServiceTest.java
+++ b/src/test/java/com/odiga/fiesta/festival/service/CategoryServiceTest.java
@@ -1,0 +1,46 @@
+package com.odiga.fiesta.festival.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.odiga.fiesta.MockTestSupport;
+import com.odiga.fiesta.festival.domain.Category;
+import com.odiga.fiesta.festival.dto.response.CategoryResponse;
+import com.odiga.fiesta.festival.repository.CategoryRepository;
+
+class CategoryServiceTest extends MockTestSupport {
+
+	@InjectMocks
+	private CategoryService categoryService;
+
+	@Mock
+	private CategoryRepository categoryRepository;
+
+	@DisplayName("모든 카테고리를 반환한다.")
+	@Test
+	void getAllCategories() {
+		// given
+		List<Category> categories = List.of(
+			Category.builder().id(1L).category("문화").build(),
+			Category.builder().id(2L).category("영화").build()
+		);
+
+		given(categoryRepository.findAll())
+			.willReturn(categories);
+
+		// when
+		final List<CategoryResponse> actual = categoryService.getAllCategories();
+
+		// then
+		assertThat(actual).usingRecursiveComparison()
+			.isEqualTo(categories.stream().map(CategoryResponse::of).toList());
+	}
+
+}

--- a/src/test/java/com/odiga/fiesta/festival/service/CompanionServiceTest.java
+++ b/src/test/java/com/odiga/fiesta/festival/service/CompanionServiceTest.java
@@ -1,0 +1,45 @@
+package com.odiga.fiesta.festival.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.odiga.fiesta.MockTestSupport;
+import com.odiga.fiesta.festival.domain.Companion;
+import com.odiga.fiesta.festival.dto.response.CompanionResponse;
+import com.odiga.fiesta.festival.repository.CompanionRepository;
+
+class CompanionServiceTest extends MockTestSupport {
+
+	@InjectMocks
+	private CompanionService companionService;
+
+	@Mock
+	private CompanionRepository companionRepository;
+
+	@DisplayName("모든 일행 타입을 반환한다.")
+	@Test
+	void getAllCompanions() {
+		// given
+		List<Companion> companions = List.of(
+			Companion.builder().id(1L).companionType("가족").build(),
+			Companion.builder().id(2L).companionType("친구").build()
+		);
+
+		given(companionRepository.findAll())
+			.willReturn(companions);
+
+		// when
+		final List<CompanionResponse> actual = companionService.getAllCompanions();
+
+		// then
+		assertThat(actual).usingRecursiveComparison()
+			.isEqualTo(companions.stream().map(CompanionResponse::of).toList());
+	}
+}

--- a/src/test/java/com/odiga/fiesta/festival/service/MoodServiceTest.java
+++ b/src/test/java/com/odiga/fiesta/festival/service/MoodServiceTest.java
@@ -1,0 +1,45 @@
+package com.odiga.fiesta.festival.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.odiga.fiesta.MockTestSupport;
+import com.odiga.fiesta.festival.domain.Mood;
+import com.odiga.fiesta.festival.dto.response.MoodResponse;
+import com.odiga.fiesta.festival.repository.MoodRepository;
+
+class MoodServiceTest extends MockTestSupport {
+
+	@InjectMocks
+	private MoodService moodService;
+
+	@Mock
+	private MoodRepository moodRepository;
+
+	@DisplayName("모든 분위기 타입을 반환한다.")
+	@Test
+	void getAllMoods() {
+		// given
+		List<Mood> moods = List.of(
+			Mood.builder().id(1L).mood("낭만적인").build(),
+			Mood.builder().id(2L).mood("모험적인").build()
+		);
+
+		given(moodRepository.findAll())
+			.willReturn(moods);
+
+		// when
+		final List<MoodResponse> actual = moodService.getAllMoods();
+
+		// then
+		assertThat(actual).usingRecursiveComparison()
+			.isEqualTo(moods.stream().map(MoodResponse::of).toList());
+	}
+}

--- a/src/test/java/com/odiga/fiesta/festival/service/PriorityServiceTest.java
+++ b/src/test/java/com/odiga/fiesta/festival/service/PriorityServiceTest.java
@@ -1,0 +1,45 @@
+package com.odiga.fiesta.festival.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.odiga.fiesta.MockTestSupport;
+import com.odiga.fiesta.festival.domain.Priority;
+import com.odiga.fiesta.festival.dto.response.PriorityResponse;
+import com.odiga.fiesta.festival.repository.PriorityRepository;
+
+class PriorityServiceTest extends MockTestSupport {
+
+	@InjectMocks
+	private PriorityService priorityService;
+
+	@Mock
+	private PriorityRepository priorityRepository;
+
+	@DisplayName("모든 페스티벌 우선순위 항목을 반환한다.")
+	@Test
+	void getAllPriorities() {
+		// given
+		List<Priority> priorities = List.of(
+			Priority.builder().id(1L).priority("주제 관심사 일치").build(),
+			Priority.builder().id(2L).priority("위치").build()
+		);
+
+		given(priorityRepository.findAll())
+			.willReturn(priorities);
+
+		// when
+		final List<PriorityResponse> actual = priorityService.getAllPriorities();
+
+		// then
+		assertThat(actual).usingRecursiveComparison()
+			.isEqualTo(priorities.stream().map(PriorityResponse::of).toList());
+	}
+}


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약

<!-- 무엇을 구현하였는지 요약해주세요. -->

온보딩 등에 사용되는 페스티벌 관련 정적 데이터 컨트롤러 구현 

# 작업 내용

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [x] [chore: jacoco 설정 변경](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/516c132c80abef3b449546364fa6b92fbfcee94e)
 -> domain 은 제외했습니다. 
- [x] [feat: 엔티티 구현](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/8b6178c5d9fd9c895a07bbba68025a63b60412d4)
- [x] [refactor: ApiResponse 이름 변경](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/10fa8206af1b868783f8a9cd509419e48e83af68)
 스웨거 애노테이션이랑 이름이 겹쳐서 변경했습니다.
- [x] [feat: FestivalController 구현](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/958d77181d3f0b4a367dce70210fbc4b413751f8)
- [x] [feat: 테스트 구현](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/aa457d895db27dd3aa16bce62781370759aed617)

# 기타 (논의하고 싶은 부분)

- 고정 데이터주는 컨트롤러는 따로 나눠야 할 지 고민입니다! (Festival 뿐만 아니라 다른 엔티티랑도 엮여 있습니다..)

![image](https://github.com/user-attachments/assets/b1c234fd-6ea1-4152-a7f4-8cbf568ac3fa)


- 단순히 고정 데이터를 주는 기능에 (화면에 뿌리기 위한 카테고리를 조회하기) 테스트를 작성하는게 묘하게 비효율적이라고 느껴졌습니다... 단순히 고정 데이터 전체를 반환하는 api 의 경우 어떤식으로 처리해야할까요?

# 타 직군 전달 사항

close #28
