### PR TITLE
feat: 페스티벌 월별 조회 API 구현

### DIFF
--- a/src/main/java/com/odiga/fiesta/common/error/ErrorCode.java
+++ b/src/main/java/com/odiga/fiesta/common/error/ErrorCode.java
@@ -15,7 +15,6 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(500, "S001", "서버에 문제가 생겼습니다."),
 	UPLOAD_FAIL(500, "S002", "파일 업로드에 실패하였습니다."),
 
-
 	// 400 Client Error
 	METHOD_NOT_ALLOWED(405, "C001", "적절하지 않은 HTTP 메소드입니다."),
 	INVALID_TYPE_VALUE(400, "C002", "요청 값의 타입이 잘못되었습니다."),
@@ -30,6 +29,9 @@ public enum ErrorCode {
 	/**
 	 * Domain
 	 */
+
+	// Festival
+	INVALID_FESTIVAL_MONTH(400, "F001", "입력된 월이 유효하지 않습니다. 월은 1월부터 12월 사이여야 합니다."),
 
 	// LOG
 	LOG_NOT_FOUND(404, "L001", "존재하지 않는 방문일지입니다.");

--- a/src/main/java/com/odiga/fiesta/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/odiga/fiesta/common/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.odiga.fiesta.common.error;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
@@ -99,6 +101,14 @@ public class GlobalExceptionHandler {
 		MissingServletRequestParameterException e) {
 		log.warn(e.getMessage(), e);
 		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.MISSING_REQUEST_PARAMETER);
+		return ResponseEntity.status(errorResponse.getStatusCode()).body(errorResponse);
+	}
+
+	// 유효성 검사 에러
+	@ExceptionHandler(HandlerMethodValidationException.class)
+	public ResponseEntity<Object> handleHandlerMethodValidationException(HandlerMethodValidationException e) {
+		log.warn(e.getMessage(), e);
+		ErrorResponse errorResponse = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
 		return ResponseEntity.status(errorResponse.getStatusCode()).body(errorResponse);
 	}
 

--- a/src/main/java/com/odiga/fiesta/festival/controller/FestivalController.java
+++ b/src/main/java/com/odiga/fiesta/festival/controller/FestivalController.java
@@ -1,23 +1,8 @@
 package com.odiga.fiesta.festival.controller;
 
-import java.util.List;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.odiga.fiesta.common.BasicResponse;
-import com.odiga.fiesta.festival.dto.response.CategoryResponse;
-import com.odiga.fiesta.festival.dto.response.CompanionResponse;
-import com.odiga.fiesta.festival.dto.response.MoodResponse;
-import com.odiga.fiesta.festival.dto.response.PriorityResponse;
-import com.odiga.fiesta.festival.service.CategoryService;
-import com.odiga.fiesta.festival.service.CompanionService;
-import com.odiga.fiesta.festival.service.MoodService;
-import com.odiga.fiesta.festival.service.PriorityService;
-
-import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -26,53 +11,4 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/festivals")
 public class FestivalController {
-
-	private final MoodService moodService;
-	private final CategoryService categoryService;
-	private final CompanionService companionService;
-	private final PriorityService priorityService;
-
-	@Operation(
-		summary = "모든 페스티벌 분위기 타입 조회",
-		description = "페스티벌 분위기 타입들을 조회합니다."
-	)
-	@GetMapping("/moods")
-	public ResponseEntity<BasicResponse<List<MoodResponse>>> getAllMoods() {
-		final BasicResponse<List<MoodResponse>> moodResponses = BasicResponse.ok(
-			"페스티벌 분위기 조회 성공", moodService.getAllMoods());
-		return ResponseEntity.ok(moodResponses);
-	}
-
-	@Operation(
-		summary = "모든 페스티벌 분류 조회",
-		description = "페스티벌 분류들을 조회합니다."
-	)
-	@GetMapping("/categories")
-	public ResponseEntity<BasicResponse<List<CategoryResponse>>> getCategories() {
-		final BasicResponse<List<CategoryResponse>> categoryResponses = BasicResponse.ok(
-			"페스티벌 카테고리 조회 성공", categoryService.getAllCategories());
-		return ResponseEntity.ok(categoryResponses);
-	}
-
-	@Operation(
-		summary = "모든 일행 분류 조회",
-		description = "일행 분류들을 조회합니다."
-	)
-	@GetMapping("/companions")
-	public ResponseEntity<BasicResponse<List<CompanionResponse>>> getCompanions() {
-		final BasicResponse<List<CompanionResponse>> companionResponses = BasicResponse.ok(
-			"페스티벌 일행 분류 조회 성공", companionService.getAllCompanions());
-		return ResponseEntity.ok(companionResponses);
-	}
-
-	@Operation(
-		summary = "모든 페스티벌 우선순위 분류 조회",
-		description = "페스티벌 우선순위 분류들을 조회합니다."
-	)
-	@GetMapping("/priorities")
-	public ResponseEntity<BasicResponse<List<PriorityResponse>>> getPriorities() {
-		final BasicResponse<List<PriorityResponse>> priorityResponses = BasicResponse.ok(
-			"페스티벌 우선순위 조회 성공", priorityService.getAllPriorities());
-		return ResponseEntity.ok(priorityResponses);
-	}
 }

--- a/src/main/java/com/odiga/fiesta/festival/controller/FestivalController.java
+++ b/src/main/java/com/odiga/fiesta/festival/controller/FestivalController.java
@@ -1,9 +1,20 @@
 package com.odiga.fiesta.festival.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.odiga.fiesta.common.BasicResponse;
+import com.odiga.fiesta.festival.dto.response.FestivalMonthlyResponse;
+import com.odiga.fiesta.festival.service.FestivalService;
+
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "Festival", description = "페스티벌 관련 API")
@@ -11,4 +22,20 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/festivals")
 public class FestivalController {
+
+	private final FestivalService festivalService;
+
+	@Operation(
+		summary = "페스티벌 월간 조회",
+		description = "페스티벌을 월간 조회합니다. 해당 월 기준으로 일자별 페스티벌이 리턴됩니다."
+	)
+	@GetMapping("/monthly")
+	public ResponseEntity<BasicResponse<FestivalMonthlyResponse>> getMonthlyFestivals(
+		@RequestParam(name = "year") @NotNull int year,
+		@RequestParam(name = "month") @Min(1) @Max(12) @NotNull int month
+	) {
+		String message = "페스티벌 월간 조회 성공";
+		final FestivalMonthlyResponse response = festivalService.getMonthlyFestivals(year, month);
+		return ResponseEntity.ok(BasicResponse.ok(message, response));
+	}
 }

--- a/src/main/java/com/odiga/fiesta/festival/controller/FestivalStaticDataController.java
+++ b/src/main/java/com/odiga/fiesta/festival/controller/FestivalStaticDataController.java
@@ -1,0 +1,78 @@
+package com.odiga.fiesta.festival.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.odiga.fiesta.common.BasicResponse;
+import com.odiga.fiesta.festival.dto.response.CategoryResponse;
+import com.odiga.fiesta.festival.dto.response.CompanionResponse;
+import com.odiga.fiesta.festival.dto.response.MoodResponse;
+import com.odiga.fiesta.festival.dto.response.PriorityResponse;
+import com.odiga.fiesta.festival.service.CategoryService;
+import com.odiga.fiesta.festival.service.CompanionService;
+import com.odiga.fiesta.festival.service.MoodService;
+import com.odiga.fiesta.festival.service.PriorityService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Festival", description = "페스티벌 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/festivals")
+public class FestivalStaticDataController {
+
+	private final MoodService moodService;
+	private final CategoryService categoryService;
+	private final CompanionService companionService;
+	private final PriorityService priorityService;
+
+	@Operation(
+		summary = "모든 페스티벌 분위기 타입 조회",
+		description = "페스티벌 분위기 타입들을 조회합니다."
+	)
+	@GetMapping("/moods")
+	public ResponseEntity<BasicResponse<List<MoodResponse>>> getAllMoods() {
+		final BasicResponse<List<MoodResponse>> moodResponses = BasicResponse.ok(
+			"페스티벌 분위기 조회 성공", moodService.getAllMoods());
+		return ResponseEntity.ok(moodResponses);
+	}
+
+	@Operation(
+		summary = "모든 페스티벌 분류 조회",
+		description = "페스티벌 분류들을 조회합니다."
+	)
+	@GetMapping("/categories")
+	public ResponseEntity<BasicResponse<List<CategoryResponse>>> getCategories() {
+		final BasicResponse<List<CategoryResponse>> categoryResponses = BasicResponse.ok(
+			"페스티벌 카테고리 조회 성공", categoryService.getAllCategories());
+		return ResponseEntity.ok(categoryResponses);
+	}
+
+	@Operation(
+		summary = "모든 일행 분류 조회",
+		description = "일행 분류들을 조회합니다."
+	)
+	@GetMapping("/companions")
+	public ResponseEntity<BasicResponse<List<CompanionResponse>>> getCompanions() {
+		final BasicResponse<List<CompanionResponse>> companionResponses = BasicResponse.ok(
+			"페스티벌 일행 분류 조회 성공", companionService.getAllCompanions());
+		return ResponseEntity.ok(companionResponses);
+	}
+
+	@Operation(
+		summary = "모든 페스티벌 우선순위 분류 조회",
+		description = "페스티벌 우선순위 분류들을 조회합니다."
+	)
+	@GetMapping("/priorities")
+	public ResponseEntity<BasicResponse<List<PriorityResponse>>> getPriorities() {
+		final BasicResponse<List<PriorityResponse>> priorityResponses = BasicResponse.ok(
+			"페스티벌 우선순위 조회 성공", priorityService.getAllPriorities());
+		return ResponseEntity.ok(priorityResponses);
+	}
+}

--- a/src/main/java/com/odiga/fiesta/festival/domain/Festival.java
+++ b/src/main/java/com/odiga/fiesta/festival/domain/Festival.java
@@ -1,17 +1,15 @@
 package com.odiga.fiesta.festival.domain;
 
 import static jakarta.persistence.GenerationType.*;
+import static java.util.stream.Collectors.*;
 import static lombok.AccessLevel.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.odiga.fiesta.common.domain.BaseEntity;
-import com.odiga.fiesta.festival.dto.response.FestivalSimpleResponse;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -21,12 +19,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @AllArgsConstructor
 @Getter
 @Builder
 @NoArgsConstructor(access = PROTECTED)
+@ToString
 public class Festival extends BaseEntity {
 
 	@Id
@@ -41,10 +41,10 @@ public class Festival extends BaseEntity {
 	private String name;
 
 	@Column(name = "start_date", nullable = false)
-	private LocalDateTime startDate;
+	private LocalDate startDate;
 
 	@Column(name = "end_date", nullable = false)
-	private LocalDateTime endDate;
+	private LocalDate endDate;
 
 	@Column(nullable = false)
 	private String address;
@@ -86,10 +86,10 @@ public class Festival extends BaseEntity {
 	public static Map<LocalDate, List<Festival>> getGroupedByDate(List<Festival> festivals) {
 		return festivals.stream()
 			.flatMap(festival ->
-				festival.getStartDate().toLocalDate().datesUntil(festival.getEndDate().toLocalDate().plusDays(1))
+				festival.getStartDate().datesUntil(festival.getEndDate().plusDays(1))
 					.map(date -> new AbstractMap.SimpleEntry<>(date, festival)))
 			.collect(
-				Collectors.groupingBy(entry -> entry.getKey(),
-					Collectors.mapping(entry -> entry.getValue(), Collectors.toList())));
+				groupingBy(AbstractMap.SimpleEntry::getKey,
+					mapping(AbstractMap.SimpleEntry::getValue, toList())));
 	}
 }

--- a/src/main/java/com/odiga/fiesta/festival/domain/Festival.java
+++ b/src/main/java/com/odiga/fiesta/festival/domain/Festival.java
@@ -3,9 +3,15 @@ package com.odiga.fiesta.festival.domain;
 import static jakarta.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.odiga.fiesta.common.domain.BaseEntity;
+import com.odiga.fiesta.festival.dto.response.FestivalSimpleResponse;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -23,58 +29,67 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public class Festival extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = IDENTITY)
-    @Column(name = "festival_id")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "festival_id")
+	private Long id;
 
-    @Column(name = "user_id")
-    private Long userId;
+	@Column(name = "user_id")
+	private Long userId;
 
-    @Column(nullable = false)
-    private String name;
+	@Column(nullable = false)
+	private String name;
 
-    @Column(name = "start_date", nullable = false)
-    private LocalDateTime startDate;
+	@Column(name = "start_date", nullable = false)
+	private LocalDateTime startDate;
 
-    @Column(name = "end_date", nullable = false)
-    private LocalDateTime endDate;
+	@Column(name = "end_date", nullable = false)
+	private LocalDateTime endDate;
 
-    @Column(nullable = false)
-    private String address;
+	@Column(nullable = false)
+	private String address;
 
-    @Column(name = "sido_id", nullable = false)
-    private Long sidoId;
+	@Column(name = "sido_id", nullable = false)
+	private Long sidoId;
 
-    @Column(nullable = false)
-    private String sigungu;
+	@Column(nullable = false)
+	private String sigungu;
 
-    @Column(nullable = false)
-    private double latitude;
+	@Column(nullable = false)
+	private double latitude;
 
-    @Column(nullable = false)
-    private double longitude;
+	@Column(nullable = false)
+	private double longitude;
 
-    @Column(nullable = false)
-    private String tip;
+	@Column(nullable = false)
+	private String tip;
 
-    @Column(name = "homepage_url", length = 1024)
-    private String homepageUrl;
+	@Column(name = "homepage_url", length = 1024)
+	private String homepageUrl;
 
-    @Column(name = "instagram_url", length = 1024)
-    private String instagramUrl;
+	@Column(name = "instagram_url", length = 1024)
+	private String instagramUrl;
 
-    private String fee;
+	private String fee;
 
-    @Column(nullable = false)
-    private String description;
+	@Column(nullable = false)
+	private String description;
 
-    @Column(name = "ticket_link", length = 1024)
-    private String ticketLink;
+	@Column(name = "ticket_link", length = 1024)
+	private String ticketLink;
 
-    private String playtime;
+	private String playtime;
 
-    @Column(name = "is_pending", nullable = false)
-    private boolean isPending;
+	@Column(name = "is_pending", nullable = false)
+	private boolean isPending;
 
+	public static Map<LocalDate, List<Festival>> getGroupedByDate(List<Festival> festivals) {
+		return festivals.stream()
+			.flatMap(festival ->
+				festival.getStartDate().toLocalDate().datesUntil(festival.getEndDate().toLocalDate().plusDays(1))
+					.map(date -> new AbstractMap.SimpleEntry<>(date, festival)))
+			.collect(
+				Collectors.groupingBy(entry -> entry.getKey(),
+					Collectors.mapping(entry -> entry.getValue(), Collectors.toList())));
+	}
 }

--- a/src/main/java/com/odiga/fiesta/festival/domain/Festival.java
+++ b/src/main/java/com/odiga/fiesta/festival/domain/Festival.java
@@ -1,13 +1,20 @@
 package com.odiga.fiesta.festival.domain;
 
-import com.odiga.fiesta.common.domain.BaseEntity;
-import jakarta.persistence.*;
-import lombok.*;
+import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
 
 import java.time.LocalDateTime;
 
-import static jakarta.persistence.GenerationType.IDENTITY;
-import static lombok.AccessLevel.PROTECTED;
+import com.odiga.fiesta.common.domain.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @AllArgsConstructor

--- a/src/main/java/com/odiga/fiesta/festival/dto/response/DailyFestivalContents.java
+++ b/src/main/java/com/odiga/fiesta/festival/dto/response/DailyFestivalContents.java
@@ -1,0 +1,23 @@
+package com.odiga.fiesta.festival.dto.response;
+
+import static com.fasterxml.jackson.annotation.JsonFormat.Shape.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class DailyFestivalContents {
+
+	@JsonFormat(shape = STRING, pattern = "yyyy-MM-dd")
+	private LocalDate date;
+	private List<FestivalSimpleResponse> festivals;
+	private Integer totalElements;
+}

--- a/src/main/java/com/odiga/fiesta/festival/dto/response/FestivalMonthlyResponse.java
+++ b/src/main/java/com/odiga/fiesta/festival/dto/response/FestivalMonthlyResponse.java
@@ -1,0 +1,15 @@
+package com.odiga.fiesta.festival.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FestivalMonthlyResponse {
+
+	private int year;
+	private int month;
+	private List<DailyFestivalContents> contents;
+}

--- a/src/main/java/com/odiga/fiesta/festival/dto/response/FestivalSimpleResponse.java
+++ b/src/main/java/com/odiga/fiesta/festival/dto/response/FestivalSimpleResponse.java
@@ -1,0 +1,24 @@
+package com.odiga.fiesta.festival.dto.response;
+
+import com.odiga.fiesta.festival.domain.Festival;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class FestivalSimpleResponse {
+
+	private Long festivalId;
+	private String name;
+
+	public static FestivalSimpleResponse of(Long festivalId, String name) {
+		return new FestivalSimpleResponse(festivalId, name);
+	}
+
+	public static FestivalSimpleResponse of(Festival festival) {
+		return new FestivalSimpleResponse(festival.getId(), festival.getName());
+	}
+}

--- a/src/main/java/com/odiga/fiesta/festival/repository/FestivalCustomRepository.java
+++ b/src/main/java/com/odiga/fiesta/festival/repository/FestivalCustomRepository.java
@@ -1,0 +1,12 @@
+package com.odiga.fiesta.festival.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.odiga.fiesta.festival.domain.Festival;
+
+public interface FestivalCustomRepository {
+
+	List<Festival> findFestivalsWithinDateRange(LocalDate startDate, LocalDate endDate);
+}
+

--- a/src/main/java/com/odiga/fiesta/festival/repository/FestivalCustomRepositoryImpl.java
+++ b/src/main/java/com/odiga/fiesta/festival/repository/FestivalCustomRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.odiga.fiesta.festival.repository;
+
+import static com.odiga.fiesta.festival.domain.QFestival.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.odiga.fiesta.festival.domain.Festival;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class FestivalCustomRepositoryImpl implements FestivalCustomRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<Festival> findFestivalsWithinDateRange(LocalDate startDate, LocalDate endDate) {
+		return queryFactory
+			.select(festival)
+			.from(festival)
+			.where(festival.startDate.between(startDate, endDate)
+				.or(festival.endDate.between(startDate, endDate))
+				.or(festival.startDate.loe(startDate).and(festival.endDate.goe(endDate)))
+			).fetch();
+	}
+}

--- a/src/main/java/com/odiga/fiesta/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/odiga/fiesta/festival/repository/FestivalRepository.java
@@ -1,7 +1,8 @@
 package com.odiga.fiesta.festival.repository;
 
-import com.odiga.fiesta.festival.domain.Festival;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.odiga.fiesta.festival.domain.Festival;
 
 public interface FestivalRepository extends JpaRepository<Festival, Long> {
 }

--- a/src/main/java/com/odiga/fiesta/festival/repository/FestivalRepository.java
+++ b/src/main/java/com/odiga/fiesta/festival/repository/FestivalRepository.java
@@ -4,5 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.odiga.fiesta.festival.domain.Festival;
 
-public interface FestivalRepository extends JpaRepository<Festival, Long> {
+public interface FestivalRepository extends JpaRepository<Festival, Long>
+	, FestivalCustomRepository {
 }

--- a/src/main/java/com/odiga/fiesta/festival/service/FestivalService.java
+++ b/src/main/java/com/odiga/fiesta/festival/service/FestivalService.java
@@ -1,0 +1,90 @@
+package com.odiga.fiesta.festival.service;
+
+import static com.odiga.fiesta.common.error.ErrorCode.*;
+import static com.odiga.fiesta.festival.domain.Festival.*;
+import static java.util.stream.Collectors.*;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.odiga.fiesta.common.error.exception.CustomException;
+import com.odiga.fiesta.festival.domain.Festival;
+import com.odiga.fiesta.festival.dto.response.DailyFestivalContents;
+import com.odiga.fiesta.festival.dto.response.FestivalMonthlyResponse;
+import com.odiga.fiesta.festival.dto.response.FestivalSimpleResponse;
+import com.odiga.fiesta.festival.repository.FestivalRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class FestivalService {
+
+	private final FestivalRepository festivalRepository;
+
+	public FestivalMonthlyResponse getMonthlyFestivals(int year, int month) {
+		validateMonth(month);
+
+		YearMonth yearMonth = YearMonth.of(year, month);
+		LocalDate startOfMonth = yearMonth.atDay(1);
+		LocalDate endOfMonth = yearMonth.atEndOfMonth();
+
+		// 날짜 기준 그룹화, 필터링
+		List<Festival> festivals = festivalRepository.findFestivalsWithinDateRange(
+			startOfMonth, endOfMonth);
+
+		Map<LocalDate, List<Festival>> groupedByDate = getFilteredGroupedByDate(festivals, startOfMonth, endOfMonth);
+		List<LocalDate> allDatesInMonth = getAllDatesInMonth(startOfMonth, endOfMonth);
+
+		List<DailyFestivalContents> dailyContents = getDailyContents(allDatesInMonth, groupedByDate);
+
+		return FestivalMonthlyResponse.builder()
+			.year(year)
+			.month(month)
+			.contents(dailyContents)
+			.build();
+	}
+
+	private static List<LocalDate> getAllDatesInMonth(LocalDate startOfMonth, LocalDate endOfMonth) {
+		return startOfMonth
+			.datesUntil(endOfMonth.plusDays(1))
+			.toList();
+	}
+
+	private static Map<LocalDate, List<Festival>> getFilteredGroupedByDate(List<Festival> festivals,
+		LocalDate startOfMonth,
+		LocalDate endOfMonth) {
+		return getGroupedByDate(festivals).entrySet().stream()
+			.filter(
+				entry -> !entry.getKey().isBefore(startOfMonth) && !entry.getKey().isAfter(endOfMonth))
+			.collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+	}
+
+	private static List<DailyFestivalContents> getDailyContents(List<LocalDate> allDatesInMonth,
+		Map<LocalDate, List<Festival>> groupedByDate) {
+		return allDatesInMonth.stream()
+			.map(date -> DailyFestivalContents.builder()
+				.date(date)
+				.festivals(groupedByDate.getOrDefault(date, List.of()).stream()
+					.map(FestivalSimpleResponse::of)
+					.limit(3)
+					.collect(toList()))
+				.totalElements(groupedByDate.getOrDefault(date, List.of()).size())
+				.build())
+			.toList();
+	}
+
+	private void validateMonth(int month) {
+		if (month < 1 || month > 12) {
+			throw new CustomException(INVALID_FESTIVAL_MONTH);
+		}
+	}
+}

--- a/src/test/java/com/odiga/fiesta/ControllerTestSupport.java
+++ b/src/test/java/com/odiga/fiesta/ControllerTestSupport.java
@@ -1,5 +1,6 @@
 package com.odiga.fiesta;
 
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -8,9 +9,11 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.odiga.fiesta.festival.controller.FestivalController;
 import com.odiga.fiesta.festival.controller.FestivalStaticDataController;
 import com.odiga.fiesta.festival.service.CategoryService;
 import com.odiga.fiesta.festival.service.CompanionService;
+import com.odiga.fiesta.festival.service.FestivalService;
 import com.odiga.fiesta.festival.service.MoodService;
 import com.odiga.fiesta.festival.service.PriorityService;
 import com.odiga.fiesta.log.controller.LogController;
@@ -20,6 +23,7 @@ import com.odiga.fiesta.log.service.LogService;
 @WithMockUser
 @WebMvcTest(controllers = {
 	// 사용하는 컨트롤러 여기에 추가
+	FestivalController.class,
 	FestivalStaticDataController.class,
 	LogController.class
 })
@@ -46,4 +50,6 @@ public abstract class ControllerTestSupport {
 	@MockBean
 	protected LogService logService;
 
+	@MockBean
+	protected FestivalService festivalService;
 }

--- a/src/test/java/com/odiga/fiesta/ControllerTestSupport.java
+++ b/src/test/java/com/odiga/fiesta/ControllerTestSupport.java
@@ -8,7 +8,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.odiga.fiesta.festival.controller.FestivalController;
+import com.odiga.fiesta.festival.controller.FestivalStaticDataController;
 import com.odiga.fiesta.festival.service.CategoryService;
 import com.odiga.fiesta.festival.service.CompanionService;
 import com.odiga.fiesta.festival.service.MoodService;
@@ -20,7 +20,7 @@ import com.odiga.fiesta.log.service.LogService;
 @WithMockUser
 @WebMvcTest(controllers = {
 	// 사용하는 컨트롤러 여기에 추가
-	FestivalController.class,
+	FestivalStaticDataController.class,
 	LogController.class
 })
 public abstract class ControllerTestSupport {

--- a/src/test/java/com/odiga/fiesta/FiestaApplicationTests.java
+++ b/src/test/java/com/odiga/fiesta/FiestaApplicationTests.java
@@ -2,6 +2,7 @@ package com.odiga.fiesta;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")

--- a/src/test/java/com/odiga/fiesta/festival/controller/FestivalControllerTest.java
+++ b/src/test/java/com/odiga/fiesta/festival/controller/FestivalControllerTest.java
@@ -1,111 +1,50 @@
 package com.odiga.fiesta.festival.controller;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 
 import com.odiga.fiesta.ControllerTestSupport;
-import com.odiga.fiesta.festival.dto.response.CategoryResponse;
-import com.odiga.fiesta.festival.dto.response.CompanionResponse;
-import com.odiga.fiesta.festival.dto.response.MoodResponse;
-import com.odiga.fiesta.festival.dto.response.PriorityResponse;
-import com.odiga.fiesta.festival.service.CategoryService;
-import com.odiga.fiesta.festival.service.CompanionService;
-import com.odiga.fiesta.festival.service.MoodService;
-import com.odiga.fiesta.festival.service.PriorityService;
+import com.odiga.fiesta.festival.dto.response.FestivalMonthlyResponse;
+import com.odiga.fiesta.festival.service.FestivalService;
 
 class FestivalControllerTest extends ControllerTestSupport {
 
-	@Autowired
-	private MoodService moodService;
+	private final String PREFIX = "/api/v1/festivals";
 
 	@Autowired
-	private CategoryService categoryService;
+	private FestivalService festivalService;
 
-	@Autowired
-	private CompanionService companionService;
-
-	@Autowired
-	private PriorityService priorityService;
-
-	@DisplayName("모든 페스티벌 분위기를 조회한다.")
+	@DisplayName("유효하지 않은 값의 month 값이 들어오면 에러가 발생한다.")
 	@Test
-	void getAllMoods() throws Exception {
-		// given
-		String message = "페스티벌 분위기 조회 성공";
-
-		List<MoodResponse> mockMoods = List.of();
-		when(moodService.getAllMoods()).thenReturn(mockMoods);
-
-		// when // then
-		mockMvc.perform(
-				get("/api/v1/festivals/moods")
-			).andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.message").value(message))
-			.andExpect(jsonPath("$.data").isArray());
+	void getMonthlyFestivals_invalidParameter() throws Exception {
+		// given // when // then
+		mockMvc.perform(get(PREFIX + "/monthly")
+				.param("year", "2023")
+				.param("month", "13"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("C003"));
 	}
 
-	@DisplayName("모든 카테고리를 조회한다.")
+	@DisplayName("특정 년, 월의 페스티벌들을 조회한다.")
 	@Test
-	void getAllCategories() throws Exception {
-		// given
-		String message = "페스티벌 카테고리 조회 성공";
+	void getMonthlyFestivals() throws Exception {
+		// Given
+		FestivalMonthlyResponse mockResponse = FestivalMonthlyResponse.builder().build();
+		when(festivalService.getMonthlyFestivals(2024, 10)).thenReturn(mockResponse);
 
-		List<CategoryResponse> mockCategories = List.of();
-		when(categoryService.getAllCategories()).thenReturn(mockCategories);
-
-		// when // then
-		mockMvc.perform(
-				get("/api/v1/festivals/categories")
-			).andDo(print())
+		// When & Then
+		mockMvc.perform(get(PREFIX + "/monthly")
+				.param("year", "2024")
+				.param("month", "10")
+				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.message").value(message))
-			.andExpect(jsonPath("$.data").isArray());
-
+			.andExpect(jsonPath("$.message").value("페스티벌 월간 조회 성공"))
+			.andExpect(jsonPath("$.data").isNotEmpty());
 	}
-
-	@DisplayName("모든 일행 타입을 조회한다.")
-	@Test
-	void getAllCompanions() throws Exception {
-		// given
-		String message = "페스티벌 일행 분류 조회 성공";
-
-		List<CompanionResponse> mockCompanions = List.of();
-		when(companionService.getAllCompanions()).thenReturn(mockCompanions);
-
-		// when // then
-		mockMvc.perform(
-				get("/api/v1/festivals/companions")
-			).andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.message").value(message))
-			.andExpect(jsonPath("$.data").isArray());
-	}
-
-	@DisplayName("모든 페스티벌 우선순위 타입을 조회한다.")
-	@Test
-	void getAllPriorities() throws Exception {
-		// given
-		String message = "페스티벌 우선순위 조회 성공";
-
-		List<PriorityResponse> mockPriorities = List.of();
-		when(priorityService.getAllPriorities()).thenReturn(mockPriorities);
-
-		// when // then
-		mockMvc.perform(
-				get("/api/v1/festivals/priorities")
-			).andDo(print())
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.message").value(message))
-			.andExpect(jsonPath("$.data").isArray());
-	}
-
 }

--- a/src/test/java/com/odiga/fiesta/festival/controller/FestivalStaticDataControllerTest.java
+++ b/src/test/java/com/odiga/fiesta/festival/controller/FestivalStaticDataControllerTest.java
@@ -1,0 +1,111 @@
+package com.odiga.fiesta.festival.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.odiga.fiesta.ControllerTestSupport;
+import com.odiga.fiesta.festival.dto.response.CategoryResponse;
+import com.odiga.fiesta.festival.dto.response.CompanionResponse;
+import com.odiga.fiesta.festival.dto.response.MoodResponse;
+import com.odiga.fiesta.festival.dto.response.PriorityResponse;
+import com.odiga.fiesta.festival.service.CategoryService;
+import com.odiga.fiesta.festival.service.CompanionService;
+import com.odiga.fiesta.festival.service.MoodService;
+import com.odiga.fiesta.festival.service.PriorityService;
+
+class FestivalStaticDataControllerTest extends ControllerTestSupport {
+
+	@Autowired
+	private MoodService moodService;
+
+	@Autowired
+	private CategoryService categoryService;
+
+	@Autowired
+	private CompanionService companionService;
+
+	@Autowired
+	private PriorityService priorityService;
+
+	@DisplayName("모든 페스티벌 분위기를 조회한다.")
+	@Test
+	void getAllMoods() throws Exception {
+		// given
+		String message = "페스티벌 분위기 조회 성공";
+
+		List<MoodResponse> mockMoods = List.of();
+		when(moodService.getAllMoods()).thenReturn(mockMoods);
+
+		// when // then
+		mockMvc.perform(
+				get("/api/v1/festivals/moods")
+			).andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value(message))
+			.andExpect(jsonPath("$.data").isArray());
+	}
+
+	@DisplayName("모든 카테고리를 조회한다.")
+	@Test
+	void getAllCategories() throws Exception {
+		// given
+		String message = "페스티벌 카테고리 조회 성공";
+
+		List<CategoryResponse> mockCategories = List.of();
+		when(categoryService.getAllCategories()).thenReturn(mockCategories);
+
+		// when // then
+		mockMvc.perform(
+				get("/api/v1/festivals/categories")
+			).andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value(message))
+			.andExpect(jsonPath("$.data").isArray());
+
+	}
+
+	@DisplayName("모든 일행 타입을 조회한다.")
+	@Test
+	void getAllCompanions() throws Exception {
+		// given
+		String message = "페스티벌 일행 분류 조회 성공";
+
+		List<CompanionResponse> mockCompanions = List.of();
+		when(companionService.getAllCompanions()).thenReturn(mockCompanions);
+
+		// when // then
+		mockMvc.perform(
+				get("/api/v1/festivals/companions")
+			).andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value(message))
+			.andExpect(jsonPath("$.data").isArray());
+	}
+
+	@DisplayName("모든 페스티벌 우선순위 타입을 조회한다.")
+	@Test
+	void getAllPriorities() throws Exception {
+		// given
+		String message = "페스티벌 우선순위 조회 성공";
+
+		List<PriorityResponse> mockPriorities = List.of();
+		when(priorityService.getAllPriorities()).thenReturn(mockPriorities);
+
+		// when // then
+		mockMvc.perform(
+				get("/api/v1/festivals/priorities")
+			).andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value(message))
+			.andExpect(jsonPath("$.data").isArray());
+	}
+
+}

--- a/src/test/java/com/odiga/fiesta/festival/domain/FestivalTest.java
+++ b/src/test/java/com/odiga/fiesta/festival/domain/FestivalTest.java
@@ -1,0 +1,132 @@
+package com.odiga.fiesta.festival.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class FestivalTest {
+
+	@DisplayName("단일 페스티벌을 날짜별로 그룹핑하면 시작일부터 종료일까지 포함해야 한다")
+	@Test
+	void getGroupedByDate_singleFestival() {
+
+		// given
+		Festival festival = createFestival(
+			LocalDateTime.of(2024, 10, 23, 0, 0),
+			LocalDateTime.of(2024, 10, 25, 23, 59)
+		);
+
+		List<Festival> festivals = Arrays.asList(festival);
+
+		Map<LocalDate, List<Festival>> expected = Map.of(
+			LocalDate.of(2024, 10, 23), Arrays.asList(festival),
+			LocalDate.of(2024, 10, 24), Arrays.asList(festival),
+			LocalDate.of(2024, 10, 25), Arrays.asList(festival)
+		);
+
+		// when
+		Map<LocalDate, List<Festival>> result = Festival.getGroupedByDate(festivals);
+
+		// then
+		assertThat(result).hasSize(3)
+			.usingRecursiveComparison()
+			.isEqualTo(expected);
+	}
+
+	@DisplayName("여러 개의 페스티벌을 날짜별로 그룹핑하면 동일한 날짜에 개최된 페스티벌을 모두 포함해야 한다")
+	@Test
+	void getGroupedByDate_multipleFestival()  {
+		// given
+		Festival festival1 = createFestival(
+			LocalDateTime.of(2024, 10, 24, 0, 0),
+			LocalDateTime.of(2024, 10, 24, 23, 59)
+		);
+
+		Festival festival2 = createFestival(
+			LocalDateTime.of(2024, 10, 24, 0, 0),
+			LocalDateTime.of(2024, 10, 24, 23, 59)
+		);
+
+		List<Festival> festivals = Arrays.asList(festival1, festival2);
+
+		Map<LocalDate, List<Festival>> expected = Map.of(
+			LocalDate.of(2024, 10, 24), Arrays.asList(festival1, festival2)
+		);
+
+		// when
+		Map<LocalDate, List<Festival>> result = Festival.getGroupedByDate(festivals);
+
+		// then
+		assertThat(result).hasSize(1)
+			.usingRecursiveComparison()
+			.isEqualTo(expected);
+	}
+
+	@DisplayName("여러 개의 페스티벌이 기간이 겹칠 때 그룹핑하면 모든 겹치는 날짜들을 포함해야 한다")
+	@Test
+	void getGroupedByDate_overlappingFestivals()  {
+		// given
+		Festival festival1 = createFestival(
+			LocalDateTime.of(2024, 10, 23, 0, 0),
+			LocalDateTime.of(2024, 10, 25, 23, 59)
+		);
+
+		Festival festival2 = createFestival(
+			LocalDateTime.of(2024, 10, 24, 0, 0),
+			LocalDateTime.of(2024, 10, 25, 23, 59)
+		);
+
+		Festival festival3 = createFestival(
+			LocalDateTime.of(2024, 10, 23, 0, 0),
+			LocalDateTime.of(2024, 10, 26, 23, 59)
+		);
+
+		List<Festival> festivals = Arrays.asList(festival1, festival2, festival3);
+
+		Map<LocalDate, List<Festival>> expected = Map.of(
+			LocalDate.of(2024, 10, 23), Arrays.asList(festival1, festival3),
+			LocalDate.of(2024, 10, 24), Arrays.asList(festival1, festival2, festival3),
+			LocalDate.of(2024, 10, 25), Arrays.asList(festival1, festival2, festival3),
+			LocalDate.of(2024, 10, 26), Arrays.asList(festival3)
+		);
+
+		// when
+		Map<LocalDate, List<Festival>> result = Festival.getGroupedByDate(festivals);
+
+		// then
+		assertThat(result).hasSize(4)
+			.usingRecursiveComparison()
+			.isEqualTo(expected);
+	}
+
+	private static Festival createFestival(LocalDateTime startDate, LocalDateTime endDate) {
+		return Festival.builder()
+			.id(1L)
+			.userId(1L)
+			.name("페스티벌 이름")
+			.startDate(startDate)
+			.endDate(endDate)
+			.address("페스티벌 주소")
+			.sidoId(1L)
+			.sigungu("시군구")
+			.latitude(10.1)
+			.longitude(10.1)
+			.tip("페스티벌 팁")
+			.homepageUrl("홈페이지 url")
+			.instagramUrl("인스타그램 url")
+			.fee("비용")
+			.description("페스티벌 상세 설명")
+			.ticketLink("티켓 링크")
+			.playtime("페스티벌 진행 시간")
+			.isPending(false)
+			.build();
+	}
+
+}

--- a/src/test/java/com/odiga/fiesta/festival/domain/FestivalTest.java
+++ b/src/test/java/com/odiga/fiesta/festival/domain/FestivalTest.java
@@ -3,8 +3,8 @@ package com.odiga.fiesta.festival.domain;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -19,16 +19,16 @@ class FestivalTest {
 
 		// given
 		Festival festival = createFestival(
-			LocalDateTime.of(2024, 10, 23, 0, 0),
-			LocalDateTime.of(2024, 10, 25, 23, 59)
+			LocalDate.of(2024, 10, 23),
+			LocalDate.of(2024, 10, 25)
 		);
 
-		List<Festival> festivals = Arrays.asList(festival);
+		List<Festival> festivals = Collections.singletonList(festival);
 
 		Map<LocalDate, List<Festival>> expected = Map.of(
-			LocalDate.of(2024, 10, 23), Arrays.asList(festival),
-			LocalDate.of(2024, 10, 24), Arrays.asList(festival),
-			LocalDate.of(2024, 10, 25), Arrays.asList(festival)
+			LocalDate.of(2024, 10, 23), Collections.singletonList(festival),
+			LocalDate.of(2024, 10, 24), Collections.singletonList(festival),
+			LocalDate.of(2024, 10, 25), Collections.singletonList(festival)
 		);
 
 		// when
@@ -45,13 +45,13 @@ class FestivalTest {
 	void getGroupedByDate_multipleFestival()  {
 		// given
 		Festival festival1 = createFestival(
-			LocalDateTime.of(2024, 10, 24, 0, 0),
-			LocalDateTime.of(2024, 10, 24, 23, 59)
+			LocalDate.of(2024, 10, 24),
+			LocalDate.of(2024, 10, 24)
 		);
 
 		Festival festival2 = createFestival(
-			LocalDateTime.of(2024, 10, 24, 0, 0),
-			LocalDateTime.of(2024, 10, 24, 23, 59)
+			LocalDate.of(2024, 10, 24),
+			LocalDate.of(2024, 10, 24)
 		);
 
 		List<Festival> festivals = Arrays.asList(festival1, festival2);
@@ -74,18 +74,18 @@ class FestivalTest {
 	void getGroupedByDate_overlappingFestivals()  {
 		// given
 		Festival festival1 = createFestival(
-			LocalDateTime.of(2024, 10, 23, 0, 0),
-			LocalDateTime.of(2024, 10, 25, 23, 59)
+			LocalDate.of(2024, 10, 23),
+			LocalDate.of(2024, 10, 25)
 		);
 
 		Festival festival2 = createFestival(
-			LocalDateTime.of(2024, 10, 24, 0, 0),
-			LocalDateTime.of(2024, 10, 25, 23, 59)
+			LocalDate.of(2024, 10, 24),
+			LocalDate.of(2024, 10, 25)
 		);
 
 		Festival festival3 = createFestival(
-			LocalDateTime.of(2024, 10, 23, 0, 0),
-			LocalDateTime.of(2024, 10, 26, 23, 59)
+			LocalDate.of(2024, 10, 23),
+			LocalDate.of(2024, 10, 26)
 		);
 
 		List<Festival> festivals = Arrays.asList(festival1, festival2, festival3);
@@ -94,7 +94,7 @@ class FestivalTest {
 			LocalDate.of(2024, 10, 23), Arrays.asList(festival1, festival3),
 			LocalDate.of(2024, 10, 24), Arrays.asList(festival1, festival2, festival3),
 			LocalDate.of(2024, 10, 25), Arrays.asList(festival1, festival2, festival3),
-			LocalDate.of(2024, 10, 26), Arrays.asList(festival3)
+			LocalDate.of(2024, 10, 26), Collections.singletonList(festival3)
 		);
 
 		// when
@@ -106,7 +106,7 @@ class FestivalTest {
 			.isEqualTo(expected);
 	}
 
-	private static Festival createFestival(LocalDateTime startDate, LocalDateTime endDate) {
+	private static Festival createFestival(LocalDate startDate, LocalDate endDate) {
 		return Festival.builder()
 			.id(1L)
 			.userId(1L)

--- a/src/test/java/com/odiga/fiesta/festival/service/FestivalServiceTest.java
+++ b/src/test/java/com/odiga/fiesta/festival/service/FestivalServiceTest.java
@@ -1,0 +1,141 @@
+package com.odiga.fiesta.festival.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.odiga.fiesta.IntegrationTestSupport;
+import com.odiga.fiesta.festival.domain.Festival;
+import com.odiga.fiesta.festival.dto.response.DailyFestivalContents;
+import com.odiga.fiesta.festival.dto.response.FestivalMonthlyResponse;
+import com.odiga.fiesta.festival.repository.FestivalRepository;
+
+class FestivalServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private FestivalService festivalService;
+
+	@Autowired
+	private FestivalRepository festivalRepository;
+
+	@DisplayName("startDate 와 endDate 사이에 해당 월이 끼어있어도 페스티벌이 포함되어야 한다.")
+	@Test
+	void getMonthlyFestivals() {
+		// given
+		int year = 2024;
+		int month = 4;
+
+		Festival festival1 = createFestival(
+			LocalDate.of(2024, 3, 25),
+			LocalDate.of(2024, 5, 5));
+
+		festivalRepository.save(festival1);
+
+		// when
+		FestivalMonthlyResponse response = festivalService.getMonthlyFestivals(year, month);
+
+		// then
+		assertNotNull(response);
+		assertEquals(year, response.getYear());
+		assertEquals(month, response.getMonth());
+
+		List<DailyFestivalContents> contents = response.getContents();
+		YearMonth yearMonth = YearMonth.of(year, month);
+
+		assertEquals(yearMonth.lengthOfMonth(), contents.size()); // 4월의 일 수와 Content의 크기 비교
+
+		List<LocalDate> allDatesInApril = Stream.iterate(yearMonth.atDay(1), date -> date.plusDays(1))
+			.limit(yearMonth.lengthOfMonth())
+			.toList();
+
+		for (int i = 0; i < contents.size(); i++) {
+			DailyFestivalContents dailyContent = contents.get(i);
+			assertEquals(allDatesInApril.get(i), dailyContent.getDate()); // 날짜 검증
+			assertEquals(1, dailyContent.getFestivals().size()); // 페스티벌 크기 검증
+			assertEquals(festival1.getName(), dailyContent.getFestivals().get(0).getName()); // 페스티벌 이름 검증
+			assertEquals(1, dailyContent.getTotalElements()); // totalElements 검증
+		}
+	}
+
+	@DisplayName("데이터가 3개 이상일 경우, 3개의 데이터만 보인다.")
+	@Test
+	void getMonthlyFestivals_Limit() {
+		// given
+		int year = 2024;
+		int month = 10;
+
+		List<Festival> festivals = new ArrayList<>();
+
+		for (int i = 0; i < 100; i++) {
+			festivals.add(createFestival(
+				LocalDate.of(2024, 10, 4),
+				LocalDate.of(2024, 10, 4)));
+		}
+
+		festivalRepository.saveAll(festivals);
+
+		// when
+		FestivalMonthlyResponse response = festivalService.getMonthlyFestivals(year, month);
+
+		// then
+		List<DailyFestivalContents> contents = response.getContents();
+		assertThat(contents.get(3).getFestivals()).hasSize(3);
+		assertThat(contents.get(3).getTotalElements()).isEqualTo(100);
+	}
+
+	@DisplayName("데이터가 없어도 빈 리스트가 출력되어야 한다.")
+	@Test
+	void getMonthlyFestivals_empty() {
+		// given
+		int year = 2024;
+		int month = 1;
+
+		Festival festival1 = createFestival(
+			LocalDate.of(2024, 3, 25),
+			LocalDate.of(2024, 5, 5));
+
+		festivalRepository.save(festival1);
+
+		// when
+		FestivalMonthlyResponse response = festivalService.getMonthlyFestivals(year, month);
+
+		// then
+		List<DailyFestivalContents> contents = response.getContents();
+
+		for (int i = 0; i < 31; i++) {
+			assertThat(contents.get(i).getFestivals()).isNotNull();
+			assertThat(contents.get(i).getFestivals()).isEmpty();
+		}
+	}
+
+	private static Festival createFestival(LocalDate startDate, LocalDate endDate) {
+		return Festival.builder()
+			.userId(1L)
+			.name("페스티벌 이름")
+			.startDate(startDate)
+			.endDate(endDate)
+			.address("페스티벌 주소")
+			.sidoId(1L)
+			.sigungu("시군구")
+			.latitude(10.1)
+			.longitude(10.1)
+			.tip("페스티벌 팁")
+			.homepageUrl("홈페이지 url")
+			.instagramUrl("인스타그램 url")
+			.fee("비용")
+			.description("페스티벌 상세 설명")
+			.ticketLink("티켓 링크")
+			.playtime("페스티벌 진행 시간")
+			.isPending(false)
+			.build();
+	}
+}


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약

페스티벌 월별 조회 API 구현


<!-- 무엇을 구현하였는지 요약해주세요. -->

# 작업 내용

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [x] [feat: FestivalCustomRepository 구현](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/9aa5a098150e779f19a82e0476e79291831a2cf9)
- [x] [feat: 페스티벌 월별 조회 API 구현](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/36719c9359558c427881f12e1c52caafc5f6cab5)
- [x] [test: 테스트 코드 작성](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/776ce1e82df8086575e2f07aeca5437cbd257856)

# 기타 (논의하고 싶은 부분)

커밋이 너무 많아져서 분리합니다!

db 에서 모든 데이터를 가져와서 java 로 필터링 하는 것보다
쿼리로 좀 더 최적화 할 수 있을 것 같은데, 우선 빠르게 구현하기 위해 그냥 두었습니다.
근데 java에서 걸러내느라 시간이 곱절로 더 걸린것같네요ㅋㅋ....

(그리고 date 쪽은 인덱스 걸어도 될 것 같아보이네요? 다른 api 구현하면서 해당 칼럼 접근 많아지면 걸어보겠습니다.)

# 타 직군 전달 사항

close #이슈번호
