### PR TITLE
feat: HOT 페스티벌 조회 API 에 종료된 페스티벌은 표시되지 않도록 수정

### DIFF
--- a/src/main/java/com/odiga/fiesta/festival/repository/FestivalCustomRepository.java
+++ b/src/main/java/com/odiga/fiesta/festival/repository/FestivalCustomRepository.java
@@ -28,7 +28,8 @@ public interface FestivalCustomRepository {
 
 	Page<FestivalWithBookmarkAndSido> findFestivalsByQuery(Long userId, String query, Pageable pageable);
 
-	Optional<FestivalDetailData> findFestivalDetail(Long userId, Long festivalId);
+	Page<FestivalWithSido> findMostLikeFestival(Pageable pageable, LocalDate date);
 
-	Page<FestivalWithSido> findMostLikeFestival(Pageable pageable);
+	Optional<FestivalDetailData> findFestivalDetail(Long userId, Long festivalId);
+	
 }

--- a/src/main/java/com/odiga/fiesta/festival/service/FestivalService.java
+++ b/src/main/java/com/odiga/fiesta/festival/service/FestivalService.java
@@ -184,9 +184,10 @@ public class FestivalService {
 
 	public Page<FestivalInfo> getHotFestivals(Pageable pageable) {
 
-		Page<FestivalWithSido> festivals = festivalRepository.findMostLikeFestival(pageable);
+		LocalDate date = LocalDate.now(clock);
+		Page<FestivalWithSido> festivals = festivalRepository.findMostLikeFestival(pageable, date);
 
-		// TODO: 배치로 변경할 수 있다.
+		// TODO: 배치로 변경할 수 있을듯...
 		List<FestivalInfo> responses = getFestivalAndSidoWithThumbnailImage(festivals);
 
 		return new PageImpl<>(responses, pageable, festivals.getTotalElements());


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약

<!-- 무엇을 구현하였는지 요약해주세요. -->

HOT 페스티벌 조회 API에 종료된 페스티벌은 표시되지 않도록 수정합니다.
수정하면서 서브쿼리를 join 으로 대체합니다.

# 작업 내용

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [x] HOT 페스티벌에 종료된 페스티벌은 표시되지 않도록 수정
- [x] 서브 쿼리 없애기 

# 기타 (논의하고 싶은 부분)

# 타 직군 전달 사항

close #75
