### PR TITLE
refactor: 페스티벌에서 가장 많이 선택된 리뷰 키워드 조회 리팩터링

### DIFF
--- a/src/main/java/com/odiga/fiesta/review/controller/ReviewController.java
+++ b/src/main/java/com/odiga/fiesta/review/controller/ReviewController.java
@@ -21,6 +21,7 @@ import com.odiga.fiesta.common.PageResponse;
 import com.odiga.fiesta.review.dto.response.ReviewKeywordResponse;
 import com.odiga.fiesta.review.dto.response.ReviewResponse;
 import com.odiga.fiesta.review.dto.response.ReviewSimpleResponse;
+import com.odiga.fiesta.review.dto.response.TopReviewKeywordsResponse;
 import com.odiga.fiesta.review.service.ReviewService;
 import com.odiga.fiesta.user.domain.User;
 
@@ -70,13 +71,11 @@ public class ReviewController {
 	}
 
 	@GetMapping("/keywords/top")
-	@Operation(summary = "가장 많이 선택된 키워드 TOP5 조회", description = "상위 5개 키워드를 조회합니다. 선택 갯수가 동률일 경우, 최근에 선택된 키워드를 조회합니다.")
-	public ResponseEntity<BasicResponse<List<ReviewKeywordResponse>>> getTop5Keywords(@RequestParam Long festivalId) {
-
-		List<ReviewKeywordResponse> keywords = reviewService.getTop5Keywords(festivalId);
-
-		String message = "가장 많이 선택된 키워드 TOP5 조회 성공";
-
-		return ResponseEntity.ok(BasicResponse.ok(message, keywords));
+	@Operation(summary = "페스티벌에서 가장 많이 선택된 리뷰 키워드 조회", description = "페스티벌 리뷰들의 상위 5개 키워드를 조회합니다. 선택 갯수가 동률일 경우, 최근에 선택된 키워드를 조회합니다.")
+	public ResponseEntity<BasicResponse<TopReviewKeywordsResponse>> getTop5Keywords(
+		@RequestParam Long festivalId,
+		@RequestParam(required = false, defaultValue = "5") Long size) {
+		TopReviewKeywordsResponse keywords = reviewService.getTopReviewKeywords(festivalId, size);
+		return ResponseEntity.ok(BasicResponse.ok("가장 많이 선택된 키워드 조회 성공", keywords));
 	}
 }

--- a/src/main/java/com/odiga/fiesta/review/dto/response/TopReviewKeywordResponse.java
+++ b/src/main/java/com/odiga/fiesta/review/dto/response/TopReviewKeywordResponse.java
@@ -1,0 +1,17 @@
+package com.odiga.fiesta.review.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TopReviewKeywordResponse {
+
+	private Long keywordId;
+	private String keyword;
+	private Long selectionCount;
+}

--- a/src/main/java/com/odiga/fiesta/review/dto/response/TopReviewKeywordsResponse.java
+++ b/src/main/java/com/odiga/fiesta/review/dto/response/TopReviewKeywordsResponse.java
@@ -1,0 +1,18 @@
+package com.odiga.fiesta.review.dto.response;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TopReviewKeywordsResponse {
+
+	private List<TopReviewKeywordResponse> keywords;
+	private Long totalCount;
+}

--- a/src/main/java/com/odiga/fiesta/review/repository/ReviewCustomRepository.java
+++ b/src/main/java/com/odiga/fiesta/review/repository/ReviewCustomRepository.java
@@ -10,6 +10,8 @@ import com.odiga.fiesta.review.dto.projection.ReviewDataWithLike;
 import com.odiga.fiesta.review.dto.projection.ReviewSimpleData;
 import com.odiga.fiesta.review.dto.response.ReviewImageResponse;
 import com.odiga.fiesta.review.dto.response.ReviewKeywordResponse;
+import com.odiga.fiesta.review.dto.response.TopReviewKeywordResponse;
+import com.odiga.fiesta.review.dto.response.TopReviewKeywordsResponse;
 
 public interface ReviewCustomRepository {
 
@@ -20,4 +22,6 @@ public interface ReviewCustomRepository {
 	Map<Long, List<ReviewImageResponse>> findReviewImagesMap(List<Long> reviewIds);
 
 	List<ReviewSimpleData> findMostLikeReviews(Long size);
+
+	TopReviewKeywordsResponse findTopReviewKeywords(Long festivalId, Long size);
 }


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약

<!-- 무엇을 구현하였는지 요약해주세요. -->

페스티벌에서 가장 많이 선택된 리뷰 키워드 조회 를 query 를 이용한 방식으로 리팩터링합니다.
또한 명세에서 변경된 response 를 반영합니다.

# 작업 내용

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [x] [feat: 페스티벌에서 가장 많이 선택된 리뷰 키워드 조회 구현](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/bd43843353fc1d230adce0b791bd8faaeaf3a294)
- [x] [test: 테스트 코드 작성](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/fab99f7cf774ca321980973e9422305ec115d9d8)

# 기타 (논의하고 싶은 부분)

# 타 직군 전달 사항

close #121 
