### PR TITLE
feat: 메소드 실행 시간을 구하기 위한 aop 구현

### DIFF
--- a/src/main/java/com/odiga/fiesta/common/aop/A.java
+++ b/src/main/java/com/odiga/fiesta/common/aop/A.java
@@ -1,4 +1,0 @@
-package com.odiga.fiesta.common.aop;
-
-public class A {
-}

--- a/src/main/java/com/odiga/fiesta/common/aop/ExeTimer.java
+++ b/src/main/java/com/odiga/fiesta/common/aop/ExeTimer.java
@@ -1,0 +1,12 @@
+package com.odiga.fiesta.common.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// https://medium.com/mo-zza/performance-test-4-aop-timer-d40b99fa5b7c
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExeTimer {
+}

--- a/src/main/java/com/odiga/fiesta/common/aop/ExpTimerImpl.java
+++ b/src/main/java/com/odiga/fiesta/common/aop/ExpTimerImpl.java
@@ -1,0 +1,36 @@
+package com.odiga.fiesta.common.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+import lombok.extern.slf4j.Slf4j;
+
+// https://medium.com/mo-zza/performance-test-4-aop-timer-d40b99fa5b7c
+@Aspect
+@Component
+@Slf4j
+public class ExpTimerImpl {
+
+	@Pointcut("@annotation(com.odiga.fiesta.common.aop.ExeTimer)")
+	private void timer() {
+	}
+
+	@Around("timer()")
+	public Object AssumeExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+		StopWatch stopWatch = new StopWatch();
+		stopWatch.start();
+		Object result = joinPoint.proceed();
+		stopWatch.stop();
+		long totalTimeMillis = stopWatch.getTotalTimeMillis();
+		MethodSignature signature = (MethodSignature)joinPoint.getSignature();
+		String methodName = signature.getMethod().getName();
+		log.info("메서드 이름 : " + methodName);
+		log.info("수행 시간 : " + totalTimeMillis + "ms");
+		return result;
+	}
+}


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약

메소드 성능 측정을 위해 실행 시간을 구하기 위한 aop 를 구현합니다.
<!-- 무엇을 구현하였는지 요약해주세요. -->

# 작업 내용

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [x] [feat: 메소드 실행 시간을 구하기 위한 aop 구현](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/6159a2eb545d9162c1a627ad4755c9ad82b13c04)

**동작 방식**
 - `ExeTimer` 
   - 해당 애노테이션은 클래스, 인터페이스, enum (`ElementType.TYPE`) / method 단위 (`ElementType.METHOD`) 에 적용 가능 
   -  `RetentionPloicy.RUNTIME` : 애노테이션이 런타임 시점까지 유지되며, JVM에 의해 런타임 중에도 참조할 수 있음
    - 구현체 `ExpTimerImpl` 에서 런타임 도중에 리플렉션을 통해 메서드 이름을 측정하거나, 런타임 실행시간을 구하기 때문에 애노테이션의 유지 기간은 runtime

- `ExpTimerImpl`
  - `@Pointcut` : ExeTimer 어노테이션이 붙은 메서드를 Join Point로 지정
  - `@Around("timer()")` : 애노테이션이 붙은 메서드가 실행 전 후의 동작을 기술
    - `joinPoint.proceed();` 로 메서드를 실행하고 결과를 받아온다.
     -> 테스트 코드에서 해당 반환값을 리턴하지 않으면 `null` 을 리턴하는 문제가 있었다.
  - 메서드 실행 이후 스탑워치를 종료하고 로그를 찍는다. 

# 기타 (논의하고 싶은 부분)

- 참고 자료 : https://medium.com/mo-zza/performance-test-4-aop-timer-d40b99fa5b7c

# 타 직군 전달 사항

close #135
