### PR TITLE
refactor: 비효율적인 쿼리 수정

### DIFF
--- a/src/main/java/com/odiga/fiesta/festival/repository/FestivalCustomRepository.java
+++ b/src/main/java/com/odiga/fiesta/festival/repository/FestivalCustomRepository.java
@@ -2,6 +2,7 @@ package com.odiga.fiesta.festival.repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -36,4 +37,6 @@ public interface FestivalCustomRepository {
 	Page<FestivalAndLocation> findUpcomingFestivalAndLocation(Long userId, LocalDate date, Pageable pageable);
 
 	List<FestivalWithSido> findRecommendFestivals(Long userTypeId, Long size, LocalDate date);
+
+	Map<Long, String> findThumbnailImageByFestivalId(List<Long> festivalIds);
 }

--- a/src/test/java/com/odiga/fiesta/festival/repository/FestivalRepositoryTest.java
+++ b/src/test/java/com/odiga/fiesta/festival/repository/FestivalRepositoryTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,7 @@ import org.springframework.data.domain.Sort;
 import com.odiga.fiesta.RepositoryTestSupport;
 import com.odiga.fiesta.festival.domain.Festival;
 import com.odiga.fiesta.festival.domain.FestivalBookmark;
+import com.odiga.fiesta.festival.domain.FestivalImage;
 import com.odiga.fiesta.festival.dto.projection.FestivalWithBookmarkAndSido;
 import com.odiga.fiesta.festival.dto.request.FestivalFilterCondition;
 import com.odiga.fiesta.sido.domain.Sido;
@@ -145,6 +147,45 @@ class FestivalRepositoryTest extends RepositoryTestSupport {
 		assertEquals(2, result.getTotalElements());
 	}
 
+	@DisplayName("페스티벌 id 로 grouping 된 이미지 하나를 조회할 수 있다.")
+	@Test
+	void findThumbnailImageByFestivalId() {
+		// given
+		Festival festival1 = createFestival();
+		Festival festival2 = createFestival();
+		Festival festival3 = createFestival();
+
+		em.persist(festival1);
+		em.persist(festival2);
+		em.persist(festival3);
+
+		FestivalImage image11 = createFestivalImage(festival1);
+		FestivalImage image12 = createFestivalImage(festival1);
+		FestivalImage image21 = createFestivalImage(festival2);
+
+		em.persist(image11);
+		em.persist(image12);
+		em.persist(image21);
+
+		// when
+		Map<Long, String> thumbnailImageByFestivalId = festivalRepository.findThumbnailImageByFestivalId(
+			List.of(festival1.getId(), festival2.getId(), festival3.getId()));
+
+		// then
+		assertThat(thumbnailImageByFestivalId).isNotNull();
+		assertThat(thumbnailImageByFestivalId.size()).isEqualTo(3);
+		assertThat(thumbnailImageByFestivalId.get(festival1.getId())).isEqualTo(image11.getImageUrl());
+		assertThat(thumbnailImageByFestivalId.get(festival2.getId())).isEqualTo(image21.getImageUrl());
+		assertThat(thumbnailImageByFestivalId.get(festival3.getId())).isNull();
+	}
+
+	private static FestivalImage createFestivalImage(Festival festival) {
+		return FestivalImage.builder()
+			.festivalId(festival.getId())
+			.imageUrl("이미지1")
+			.build();
+	}
+
 	private static Festival createFestival(LocalDate startDate, LocalDate endDate, Long sidoId) {
 		return Festival.builder()
 			.userId(1L)
@@ -173,6 +214,28 @@ class FestivalRepositoryTest extends RepositoryTestSupport {
 			.name("페스티벌 이름")
 			.startDate(startDate)
 			.endDate(endDate)
+			.address("페스티벌 주소")
+			.sidoId(1L)
+			.sigungu("시군구")
+			.latitude(10.1)
+			.longitude(10.1)
+			.tip("페스티벌 팁")
+			.homepageUrl("홈페이지 url")
+			.instagramUrl("인스타그램 url")
+			.fee("비용")
+			.description("페스티벌 상세 설명")
+			.ticketLink("티켓 링크")
+			.playtime("페스티벌 진행 시간")
+			.isPending(false)
+			.build();
+	}
+
+	private static Festival createFestival() {
+		return Festival.builder()
+			.userId(1L)
+			.name("페스티벌 이름")
+			.startDate(LocalDate.of(2024, 10, 1))
+			.endDate(LocalDate.of(2024, 10, 10))
 			.address("페스티벌 주소")
 			.sidoId(1L)
 			.sigungu("시군구")


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약

<!-- 무엇을 구현하였는지 요약해주세요. -->

`n + 1`을 만들어내는 메서드를 수정합니다.

# 작업 내용

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [x] 한방쿼리 작성 
- [x] 테스트

# 기타 (논의하고 싶은 부분)

너무나도 예정된 병목이라 부하테스트 툴은 사용하지 않고,
테스트코드에서 100개정도 데이터 넣어서 실행해본 결과
```java
@DisplayName("페스티벌 필터 조회 - 성능 확인")  
@Test  
void test() {  
    // given  
    FestivalFilterRequest filterRequest = FestivalFilterRequest.builder()  
       .build();  
  
    List<Festival> festivals = new ArrayList<>();  
  
    for (int i = 0; i < 100; i++) {  
       Festival festival = createFestival("페스티벌" + i);  
       festivals.add(festival);  
    }  
  
    festivalRepository.saveAll(festivals);  
  
    List<FestivalImage> images = new ArrayList<>();  
  
    festivals.forEach(festival -> {  
       FestivalImage image1 = FestivalImage.builder().festivalId(festival.getId()).imageUrl("imageUrl1").build();  
       FestivalImage image2 = FestivalImage.builder().festivalId(festival.getId()).imageUrl("imageUrl2").build();  
       FestivalImage image3 = FestivalImage.builder().festivalId(festival.getId()).imageUrl("imageUrl3").build();  
       images.add(image1);  
       images.add(image2);  
       images.add(image3);  
    });  
  
    festivalImageRepository.saveAll(images);  
  
    // when  
    festivalService.getFestivalByFiltersAndSort(null, filterRequest, null, null, PageRequest.of(0, 100));  
  
    // then  
}
```

1. `getFestivalByFiltersAndSort`
2. 
(해당 테스트 코드)
<데이터 100개에 대해서>

(최적화 전)

![](https://i.imgur.com/92HJUE2.png)

2024-08-30T00:06:13.676+09:00  INFO 10729 --- [    Test worker] c.odiga.fiesta.common.aop.ExpTimerImpl   : 메서드 이름 : getFestivalByFiltersAndSort
2024-08-30T00:06:13.676+09:00  INFO 10729 --- [    Test worker] c.odiga.fiesta.common.aop.ExpTimerImpl   : 수행 시간 : 1059ms

(최적화 후)
![](https://i.imgur.com/rfIqc7x.png)


2024-08-30T00:04:32.682+09:00  INFO 10662 --- [    Test worker] c.odiga.fiesta.common.aop.ExpTimerImpl   : 메서드 이름 : getFestivalByFiltersAndSort
2024-08-30T00:04:32.682+09:00  INFO 10662 --- [    Test worker] c.odiga.fiesta.common.aop.ExpTimerImpl   : 수행 시간 : 775ms


2. `getFestivalsByQuery`
이전
![](https://i.imgur.com/uuf6UWT.png)

이후
![](https://i.imgur.com/BjmK7X9.png)

3. `getFestivalsByDay`
이전
![](https://i.imgur.com/7qV9vYF.png)

이후
![](https://i.imgur.com/c4UNOBn.png)


일단 눈에 보이는 차이는 있는 걸로.. (너무 자명한 이야기)

# 타 직군 전달 사항

close #134 
