### PR TITLE
feat: list 형태로 들어오는 값들의 중복 제거 로직 추가

### DIFF
--- a/src/main/java/com/odiga/fiesta/festival/dto/request/FestivalCreateRequest.java
+++ b/src/main/java/com/odiga/fiesta/festival/dto/request/FestivalCreateRequest.java
@@ -3,6 +3,7 @@ package com.odiga.fiesta.festival.dto.request;
 import static com.fasterxml.jackson.annotation.JsonFormat.Shape.*;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -42,7 +43,7 @@ public class FestivalCreateRequest {
 	private String sido;
 
 	private String sigungu;
-	
+
 	private String playtime;
 
 	private String homepageUrl;
@@ -61,9 +62,9 @@ public class FestivalCreateRequest {
 
 	@Builder
 	public FestivalCreateRequest(String name, String description, LocalDate startDate, LocalDate endDate,
-		String address,
-		Double latitude, Double longitude, String sido, String sigungu, String playtime, String homepageUrl,
-		String instagramUrl, String ticketLink, String fee, List<Long> categoryIds, List<Long> moodIds, String tip) {
+		String address, Double latitude, Double longitude, String sido, String sigungu,
+		String playtime, String homepageUrl, String instagramUrl, String ticketLink,
+		String fee, List<Long> categoryIds, List<Long> moodIds, String tip) {
 		this.name = name;
 		this.description = description;
 		this.startDate = startDate;
@@ -78,8 +79,12 @@ public class FestivalCreateRequest {
 		this.instagramUrl = instagramUrl;
 		this.ticketLink = ticketLink;
 		this.fee = fee;
-		this.categoryIds = categoryIds;
-		this.moodIds = moodIds;
+		this.categoryIds = removeDuplicates(categoryIds);
+		this.moodIds = removeDuplicates(moodIds);
 		this.tip = tip;
+	}
+
+	private List<Long> removeDuplicates(List<Long> list) {
+		return list == null ? Collections.emptyList()  : list.stream().distinct().toList();
 	}
 }

--- a/src/main/java/com/odiga/fiesta/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/odiga/fiesta/review/dto/request/ReviewCreateRequest.java
@@ -12,7 +12,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
 public class ReviewCreateRequest {
 
 	@NotNull
@@ -32,5 +31,17 @@ public class ReviewCreateRequest {
 	@AssertTrue(message = "평점은 0.5 단위로 입력해야 합니다.")
 	private boolean isRatingValid() {
 		return rating != null && (rating * 10) % 5 == 0;
+	}
+
+	@Builder
+	public ReviewCreateRequest(Long festivalId, Double rating, List<Long> keywordIds, String content) {
+		this.festivalId = festivalId;
+		this.rating = rating;
+		this.keywordIds = removeDuplicates(keywordIds);
+		this.content = content;
+	}
+
+	private List<Long> removeDuplicates(List<Long> list) {
+		return list == null ? null : list.stream().distinct().toList();
 	}
 }

--- a/src/main/java/com/odiga/fiesta/review/dto/request/ReviewUpdateRequest.java
+++ b/src/main/java/com/odiga/fiesta/review/dto/request/ReviewUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.odiga.fiesta.review.dto.request;
 
+import java.util.Collections;
 import java.util.List;
 
 import jakarta.validation.constraints.AssertTrue;
@@ -9,7 +10,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
 public class ReviewUpdateRequest {
 
 	@NotNull
@@ -27,5 +27,17 @@ public class ReviewUpdateRequest {
 	@AssertTrue(message = "평점은 0.5 단위로 입력해야 합니다.")
 	private boolean isRatingValid() {
 		return rating != null && (rating * 10) % 5 == 0;
+	}
+
+	@Builder
+	public ReviewUpdateRequest(Double rating, List<Long> keywordIds, List<Long> deletedImages, String content) {
+		this.rating = rating;
+		this.keywordIds = removeDuplicates(keywordIds);
+		this.deletedImages = removeDuplicates(deletedImages);
+		this.content = content;
+	}
+
+	private List<Long> removeDuplicates(List<Long> list) {
+		return list == null ? Collections.emptyList() : list.stream().distinct().toList();
 	}
 }


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약

<!-- 무엇을 구현하였는지 요약해주세요. -->

request 에 중복된 아이디가 들어오면 키워드가 여러개가 되는 오류를 수정합니다.

# 작업 내용

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [x] [feat: list 형태로 들어오는 값들의 중복 제거 로직 추가](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/c1b18d4e46bdbd3faeaeb85bc80edfaafef7d2b3)
- [x] [test: 테스트 코드 작성](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/6825e71c0c1f44cb3991a6eeb8d160f7255ea36f)

# 기타 (논의하고 싶은 부분)

# 타 직군 전달 사항

close #133 
