### PR TITLE
fix: 유저의 활동뱃지가 중복으로 획득되는 에러 수정

### DIFF
--- a/src/main/java/com/odiga/fiesta/badge/repository/BadgeCustomRepositoryImpl.java
+++ b/src/main/java/com/odiga/fiesta/badge/repository/BadgeCustomRepositoryImpl.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import com.odiga.fiesta.user.dto.response.UserBadgeResponse;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -39,7 +40,12 @@ public class BadgeCustomRepositoryImpl implements BadgeCustomRepository {
 			)
 			.from(badge)
 			.leftJoin(userBadge)
-			.on(badge.id.eq(userBadge.badgeId)) // 단순 조인
+			.on(badgeIdEq())
+			.distinct()
 			.fetch();
+	}
+
+	private static BooleanExpression badgeIdEq() {
+		return badge.id.eq(userBadge.badgeId);
 	}
 }

--- a/src/main/java/com/odiga/fiesta/badge/repository/UserBadgeRepository.java
+++ b/src/main/java/com/odiga/fiesta/badge/repository/UserBadgeRepository.java
@@ -12,4 +12,6 @@ public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {
 
 	@Query("SELECT ub.badgeId FROM UserBadge ub WHERE ub.userId= :userId AND ub.badgeId IN :badgeIds")
 	List<Long> findBadgeIdByUserIdAndBadgeIdIn(@Param("userId") Long userId, @Param("badgeIds") List<Long> badgeIds);
+
+	Boolean existsByBadgeId(Long badgeId);
 }


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약

<!-- 무엇을 구현하였는지 요약해주세요. -->

# 작업 내용

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [x] 활동뱃지가 중복으로 수여되지 않도록 수정
- [x] 쿼리에 distinct 추가 

# 기타 (논의하고 싶은 부분)

비동기라서 그 사이에 다른 스레드가 낀다면 update 중간에 예상치 못한 동작이 발생할 수 있을 것 같음
뱃지 업데이트 전에 조회할때 그럴떄 뱃지 업데이트중에 로그인 광클한다면..? 뭔가 문제가 생길수있지 않을까
# 타 직군 전달 사항

close #166
