### PR TITLE
feat: 유저의 온보딩 정보 조회 api 구현

### DIFF
--- a/src/main/java/com/odiga/fiesta/user/controller/UserController.java
+++ b/src/main/java/com/odiga/fiesta/user/controller/UserController.java
@@ -37,6 +37,7 @@ import com.odiga.fiesta.user.dto.response.TokenReissueResponse;
 import com.odiga.fiesta.user.dto.response.UserBadgeResponse;
 import com.odiga.fiesta.user.dto.response.UserIdResponse;
 import com.odiga.fiesta.user.dto.response.UserInfoResponse;
+import com.odiga.fiesta.user.dto.response.UserOnboardingResponse;
 import com.odiga.fiesta.user.service.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -58,7 +59,7 @@ public class UserController {
 	private final AuthService authService;
 	private final BadgeService badgeService;
 	private final FestivalService festivalService;
-	
+
 	@PostMapping("/oauth/login")
 	@Operation(summary = "소셜 로그인", description = "소셜 로그인을 진행합니다.")
 	public ResponseEntity<BasicResponse<LoginResponse>> kakaoLogin(@RequestBody SocialLoginRequest request) {
@@ -142,5 +143,13 @@ public class UserController {
 
 		UserIdResponse response = userService.updateUserInfo(user, request);
 		return ResponseEntity.ok(BasicResponse.ok("내 정보 수정 성공", response));
+	}
+
+	@PatchMapping("/onboarding-info")
+	@Operation(summary = "유저의 온보딩 응답 정보 조회 성공", description = "유저의 온보딩 응답 정보 조회 성공를 조회합니다.")
+	public ResponseEntity<BasicResponse<UserOnboardingResponse>> getOnboardingInfo(@AuthUser User user) {
+
+		UserOnboardingResponse response = userService.getOnboardingInfo(user);
+		return ResponseEntity.ok(BasicResponse.ok("유저의 온보딩 응답 정보 조회 성공", response));
 	}
 }

--- a/src/main/java/com/odiga/fiesta/user/dto/response/UserOnboardingResponse.java
+++ b/src/main/java/com/odiga/fiesta/user/dto/response/UserOnboardingResponse.java
@@ -1,0 +1,25 @@
+package com.odiga.fiesta.user.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class UserOnboardingResponse {
+	private List<Long> categoryIds;
+	private List<Long> moodIds;
+	private List<Long> companionIds;
+	private List<Long> priorityIds;
+
+	@Builder
+	private UserOnboardingResponse(List<Long> categoryIds, List<Long> moodIds, List<Long> companionIds,
+		List<Long> priorityIds) {
+		this.categoryIds = categoryIds;
+		this.moodIds = moodIds;
+		this.companionIds = companionIds;
+		this.priorityIds = priorityIds;
+	}
+}

--- a/src/main/java/com/odiga/fiesta/user/repository/UserCategoryRepository.java
+++ b/src/main/java/com/odiga/fiesta/user/repository/UserCategoryRepository.java
@@ -1,8 +1,16 @@
 package com.odiga.fiesta.user.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.odiga.fiesta.user.domain.mapping.UserCategory;
 
 public interface UserCategoryRepository extends JpaRepository<UserCategory, Long> {
+
+	@Query("SELECT uc.categoryId FROM UserCategory uc WHERE uc.userId = :userId")
+	List<Long> findCategoryIdsByUserId(@Param("userId") Long userId);
+
 }

--- a/src/main/java/com/odiga/fiesta/user/repository/UserCompanionRepository.java
+++ b/src/main/java/com/odiga/fiesta/user/repository/UserCompanionRepository.java
@@ -1,8 +1,15 @@
 package com.odiga.fiesta.user.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.odiga.fiesta.user.domain.mapping.UserCompanion;
 
 public interface UserCompanionRepository extends JpaRepository<UserCompanion, Long> {
+
+	@Query("SELECT uc.companionId FROM UserCompanion uc WHERE uc.userId = :userId")
+	List<Long> findCompanionIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/odiga/fiesta/user/repository/UserMoodRepository.java
+++ b/src/main/java/com/odiga/fiesta/user/repository/UserMoodRepository.java
@@ -1,8 +1,16 @@
 package com.odiga.fiesta.user.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.odiga.fiesta.user.domain.mapping.UserMood;
 
 public interface UserMoodRepository extends JpaRepository<UserMood, Long> {
+
+
+	@Query("SELECT um.moodId FROM UserMood um WHERE um.userId = :userId")
+	List<Long> findMoodIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/odiga/fiesta/user/repository/UserPriorityRepository.java
+++ b/src/main/java/com/odiga/fiesta/user/repository/UserPriorityRepository.java
@@ -1,8 +1,16 @@
 package com.odiga.fiesta.user.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.odiga.fiesta.user.domain.mapping.UserPriority;
 
+import io.lettuce.core.dynamic.annotation.Param;
+
 public interface UserPriorityRepository extends JpaRepository<UserPriority, Long> {
+
+	@Query("SELECT up.priorityId FROM UserPriority up WHERE up.userId = :userId")
+	List<Long> findPriorityIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/odiga/fiesta/user/service/UserService.java
+++ b/src/main/java/com/odiga/fiesta/user/service/UserService.java
@@ -42,6 +42,7 @@ import com.odiga.fiesta.user.dto.request.UserInfoUpdateRequest;
 import com.odiga.fiesta.user.dto.response.ProfileCreateResponse;
 import com.odiga.fiesta.user.dto.response.UserIdResponse;
 import com.odiga.fiesta.user.dto.response.UserInfoResponse;
+import com.odiga.fiesta.user.dto.response.UserOnboardingResponse;
 import com.odiga.fiesta.user.repository.UserCategoryRepository;
 import com.odiga.fiesta.user.repository.UserCompanionRepository;
 import com.odiga.fiesta.user.repository.UserMoodRepository;
@@ -56,9 +57,6 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserService {
-
-	private final FestivalRepository festivalRepository;
-	private final FestivalService festivalService;
 
 	private final UserCategoryRepository userCategoryRepository;
 	private final UserCompanionRepository userCompanionRepository;
@@ -163,6 +161,22 @@ public class UserService {
 		);
 	}
 
+	public UserOnboardingResponse getOnboardingInfo(User user) {
+		validateUser(user);
+
+		List<Long> categoryIds = userCategoryRepository.findCategoryIdsByUserId(user.getId());
+		List<Long> moodIds = userMoodRepository.findMoodIdsByUserId(user.getId());
+		List<Long> companionIds = userCompanionRepository.findCompanionIdsByUserId(user.getId());
+		List<Long> priorityIds = userPriorityRepository.findPriorityIdsByUserId(user.getId());
+
+		return UserOnboardingResponse.builder()
+			.categoryIds(categoryIds)
+			.moodIds(moodIds)
+			.companionIds(companionIds)
+			.priorityIds(priorityIds)
+			.build();
+	}
+
 	private void validateCompanions(List<Long> companionIds) {
 		List<Companion> companions = companionRepository.findAllById(companionIds);
 		if (companions.size() != companionIds.size()) {
@@ -200,4 +214,5 @@ public class UserService {
 			throw new CustomException(USER_NOT_FOUND);
 		}
 	}
+
 }

--- a/src/test/java/com/odiga/fiesta/user/service/UserServiceTest.java
+++ b/src/test/java/com/odiga/fiesta/user/service/UserServiceTest.java
@@ -37,6 +37,7 @@ import com.odiga.fiesta.user.dto.request.ProfileCreateRequest;
 import com.odiga.fiesta.user.dto.request.UserInfoUpdateRequest;
 import com.odiga.fiesta.user.dto.response.ProfileCreateResponse;
 import com.odiga.fiesta.user.dto.response.UserIdResponse;
+import com.odiga.fiesta.user.dto.response.UserOnboardingResponse;
 import com.odiga.fiesta.user.repository.UserCategoryRepository;
 import com.odiga.fiesta.user.repository.UserCompanionRepository;
 import com.odiga.fiesta.user.repository.UserMoodRepository;
@@ -191,6 +192,46 @@ class UserServiceTest extends MockTestSupport {
 
 		// then
 		assertThat(exception.getErrorCode()).isEqualTo(INVALID_STATUS_MESSAGE_LENGTH);
+	}
+
+	@DisplayName("유저의 온보딩 정보 조회 - 성공")
+	@Test
+	void getOnboardingInfo() {
+		// given
+		User user = createNoProfileUser();
+
+		ProfileCreateRequest request = ProfileCreateRequest.builder()
+			.priorityIds(List.of(1L, 2L))
+			.moodIds(List.of(1L, 2L))
+			.categoryIds(List.of(1L, 2L))
+			.companionIds(List.of(1L, 2L))
+			.build();
+
+		UserType userType = UserType.builder()
+			.id(1L)
+			.name("힐링러")
+			.profileImage("힐링러 프로필 이미지")
+			.cardImage("힐링러 카드 이미지")
+			.build();
+
+		given(userRepository.existsById(user.getId())).willReturn(true);
+		given(userCategoryRepository.findCategoryIdsByUserId(user.getId())).willReturn(request.getCategoryIds());
+		given(userMoodRepository.findMoodIdsByUserId(user.getId())).willReturn(request.getMoodIds());
+		given(userCompanionRepository.findCompanionIdsByUserId(user.getId())).willReturn(request.getCompanionIds());
+		given(userPriorityRepository.findPriorityIdsByUserId(user.getId())).willReturn(request.getPriorityIds());
+
+		// when
+		UserOnboardingResponse onboardingInfo = userService.getOnboardingInfo(user);
+
+		// then
+		assertThat(onboardingInfo)
+			.extracting("categoryIds", "moodIds", "companionIds", "priorityIds")
+			.containsExactly(
+				request.getCategoryIds(),
+				request.getMoodIds(),
+				request.getCompanionIds(),
+				request.getPriorityIds()
+			);
 	}
 
 	User createNoProfileUser() {


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약

유저가 온보딩 시 선택했던 정보를 조회하는 api를 구현한다. 
<!-- 무엇을 구현하였는지 요약해주세요. -->

# 작업 내용

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [x] 유저의 온보딩 정보 조회 api 구현
- [x] 테스트 코드 작성

# 기타 (논의하고 싶은 부분)

# 타 직군 전달 사항

close #173
