### PR TITLE
feat: 유저 타입 수정 api (프로필 수정) 구현

### DIFF
--- a/src/main/java/com/odiga/fiesta/user/controller/UserController.java
+++ b/src/main/java/com/odiga/fiesta/user/controller/UserController.java
@@ -96,12 +96,21 @@ public class UserController {
 	}
 
 	@PostMapping("/profile")
-	@Operation(summary = "프로필 생성", description = "프로필을 생성합니다.")
+	@Operation(summary = "프로필(유저 타입) 생성", description = "프로필을 생성합니다.")
 	public ResponseEntity<BasicResponse<ProfileCreateResponse>> createProfile(@AuthUser User user,
 		@RequestBody @Valid ProfileCreateRequest request) {
 
 		ProfileCreateResponse response = userService.createProfile(user, request);
 		return ResponseEntity.ok(BasicResponse.ok("프로필 생성 성공", response));
+	}
+
+	@PatchMapping("/profile")
+	@Operation(summary = "프로필(유저 타입) 수정", description = "프로필(유저 타입)을 수정합니다.")
+	public ResponseEntity<BasicResponse<ProfileCreateResponse>> updateProfile(@AuthUser User user,
+		@RequestBody @Valid ProfileCreateRequest request) {
+
+		ProfileCreateResponse response = userService.updateProfile(user, request);
+		return ResponseEntity.ok(BasicResponse.ok("프로필 수정 성공", response));
 	}
 
 	@PostMapping("/reissue")

--- a/src/main/java/com/odiga/fiesta/user/domain/mapping/UserCategory.java
+++ b/src/main/java/com/odiga/fiesta/user/domain/mapping/UserCategory.java
@@ -9,13 +9,16 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "user_category")
+@Table(name = "user_category", indexes = {
+    @Index(name = "idx_user_category", columnList = "user_id, category_id")
+})
 @SuperBuilder
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor(access = PRIVATE)

--- a/src/main/java/com/odiga/fiesta/user/domain/mapping/UserCompanion.java
+++ b/src/main/java/com/odiga/fiesta/user/domain/mapping/UserCompanion.java
@@ -9,13 +9,16 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "user_companion")
+@Table(name = "user_companion", indexes = {
+    @Index(name = "idx_user_companion", columnList = "user_id, companion_type_id")
+})
 @SuperBuilder
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor(access = PRIVATE)

--- a/src/main/java/com/odiga/fiesta/user/domain/mapping/UserMood.java
+++ b/src/main/java/com/odiga/fiesta/user/domain/mapping/UserMood.java
@@ -9,13 +9,16 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "user_mood")
+@Table(name = "user_mood", indexes = {
+    @Index(name = "idx_user_mood", columnList = "user_id, mood_id")
+})
 @SuperBuilder
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor(access = PRIVATE)

--- a/src/main/java/com/odiga/fiesta/user/domain/mapping/UserPriority.java
+++ b/src/main/java/com/odiga/fiesta/user/domain/mapping/UserPriority.java
@@ -9,13 +9,16 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Entity
-@Table(name = "user_priority")
+@Table(name = "user_priority", indexes = {
+    @Index(name = "idx_user_priority", columnList = "user_id, priority_id")
+})
 @SuperBuilder
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor(access = PRIVATE)

--- a/src/main/java/com/odiga/fiesta/user/repository/UserCategoryRepository.java
+++ b/src/main/java/com/odiga/fiesta/user/repository/UserCategoryRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.odiga.fiesta.user.domain.mapping.UserCategory;
 
 public interface UserCategoryRepository extends JpaRepository<UserCategory, Long> {
+
+	void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/odiga/fiesta/user/repository/UserCompanionRepository.java
+++ b/src/main/java/com/odiga/fiesta/user/repository/UserCompanionRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.odiga.fiesta.user.domain.mapping.UserCompanion;
 
 public interface UserCompanionRepository extends JpaRepository<UserCompanion, Long> {
+
+	void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/odiga/fiesta/user/repository/UserMoodRepository.java
+++ b/src/main/java/com/odiga/fiesta/user/repository/UserMoodRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.odiga.fiesta.user.domain.mapping.UserMood;
 
 public interface UserMoodRepository extends JpaRepository<UserMood, Long> {
+
+	void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/odiga/fiesta/user/repository/UserMoodRepository.java
+++ b/src/main/java/com/odiga/fiesta/user/repository/UserMoodRepository.java
@@ -3,6 +3,8 @@ package com.odiga.fiesta.user.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.odiga.fiesta.user.domain.mapping.UserMood;
 

--- a/src/main/java/com/odiga/fiesta/user/repository/UserPriorityRepository.java
+++ b/src/main/java/com/odiga/fiesta/user/repository/UserPriorityRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.odiga.fiesta.user.domain.mapping.UserPriority;
 
 public interface UserPriorityRepository extends JpaRepository<UserPriority, Long> {
+
+	void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/odiga/fiesta/user/service/UserService.java
+++ b/src/main/java/com/odiga/fiesta/user/service/UserService.java
@@ -75,6 +75,7 @@ public class UserService {
 	@Transactional
 	public ProfileCreateResponse createProfile(User user, ProfileCreateRequest request) {
 		validateUser(user);
+		deleteOnboardingInfo(user);
 		UserType userType = createUserType(user, request);
 
 		// response
@@ -89,7 +90,6 @@ public class UserService {
 	public ProfileCreateResponse updateProfile(User user, ProfileCreateRequest request) {
 
 		validateUser(user);
-		// 이전의 정보 삭제
 		deleteOnboardingInfo(user);
 
 		UserType userType = createUserType(user, request);

--- a/src/main/resources/db/migration/V29__create_idx_to_onboarding.sql
+++ b/src/main/resources/db/migration/V29__create_idx_to_onboarding.sql
@@ -1,0 +1,4 @@
+CREATE INDEX idx_user_category ON user_category (user_id, category_id);
+CREATE INDEX idx_user_companion ON user_companion (user_id, companion_type_id);
+CREATE INDEX idx_user_mood ON user_mood (user_id, mood_id);
+CREATE INDEX idx_user_priority ON user_priority (user_id, priority_id);

--- a/src/test/java/com/odiga/fiesta/user/service/UserServiceMockTest.java
+++ b/src/test/java/com/odiga/fiesta/user/service/UserServiceMockTest.java
@@ -6,17 +6,12 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 
 import com.odiga.fiesta.MockTestSupport;
 import com.odiga.fiesta.category.domain.Category;
@@ -25,7 +20,6 @@ import com.odiga.fiesta.common.error.exception.CustomException;
 import com.odiga.fiesta.companion.domain.Companion;
 import com.odiga.fiesta.companion.repository.CompanionRepository;
 import com.odiga.fiesta.festival.domain.Festival;
-import com.odiga.fiesta.festival.dto.response.FestivalInfoWithBookmark;
 import com.odiga.fiesta.festival.repository.FestivalRepository;
 import com.odiga.fiesta.mood.domain.Mood;
 import com.odiga.fiesta.mood.repository.MoodRepository;
@@ -43,7 +37,7 @@ import com.odiga.fiesta.user.repository.UserMoodRepository;
 import com.odiga.fiesta.user.repository.UserPriorityRepository;
 import com.odiga.fiesta.user.repository.UserRepository;
 
-class UserServiceTest extends MockTestSupport {
+class UserServiceMockTest extends MockTestSupport {
 
 	@InjectMocks
 	private UserService userService;
@@ -130,6 +124,37 @@ class UserServiceTest extends MockTestSupport {
 		verify(userCompanionRepository).saveAll(anyList());
 	}
 
+	@DisplayName("프로필 수정 - 이전의 온보딩 정보가 삭제되어야 한다.")
+	@Test
+	void updateUserInfo_ShouldDeleteOnboardingInfo() {
+		// given
+		User user = createNoProfileUser();
+		Long userId = user.getId();
+		given(userRepository.existsById(userId)).willReturn(true);
+
+		ProfileCreateRequest currentOnboardingInfo = createProfileCreateRequest();
+		mockRepositoriesForCreateProfileRequest(currentOnboardingInfo);
+
+		UserType nextUserType = UserType.builder()
+			.id(2L)
+			.name("수정된 user type")
+			.profileImage("프로필 이미지")
+			.cardImage("카드 이미지")
+			.build();
+
+		given(userTypeService.getTopNUserTypes(currentOnboardingInfo.getCategoryIds(),
+			currentOnboardingInfo.getMoodIds(), 1))
+			.willReturn(List.of(nextUserType));
+
+		// when
+		ProfileCreateResponse response = userService.updateProfile(user, currentOnboardingInfo);
+
+		// then
+		verifyRepositoriesDeletion(userId);
+		verifyRepositoriesSave();
+		assertEquals(user.getUserTypeId(), nextUserType.getId());
+	}
+
 	@DisplayName("유저 정보 수정 - 성공")
 	@Test
 	void updateUserInfo_Success() {
@@ -191,6 +216,59 @@ class UserServiceTest extends MockTestSupport {
 
 		// then
 		assertThat(exception.getErrorCode()).isEqualTo(INVALID_STATUS_MESSAGE_LENGTH);
+	}
+
+	private static ProfileCreateRequest createProfileCreateRequest() {
+		return ProfileCreateRequest.builder()
+			.categoryIds(List.of(11L, 12L))
+			.moodIds(List.of(11L, 12L, 13L))
+			.companionIds(List.of(11L, 12L))
+			.priorityIds(List.of(11L, 12L, 13L))
+			.build();
+	}
+
+	private void mockRepositoriesForCreateProfileRequest(ProfileCreateRequest request) {
+		given(priorityRepository.findAllById(request.getPriorityIds()))
+			.willReturn(List.of(
+				Priority.builder().id(11L).build(),
+				Priority.builder().id(12L).build(),
+				Priority.builder().id(13L).build()
+			));
+
+		given(moodRepository.findAllById(request.getMoodIds()))
+			.willReturn(List.of(
+				Mood.builder().id(11L).build(),
+				Mood.builder().id(12L).build(),
+				Mood.builder().id(13L).build()
+			));
+
+		given(categoryRepository.findAllById(request.getCategoryIds()))
+			.willReturn(List.of(
+				Category.builder().id(11L).build(),
+				Category.builder().id(12L).build()
+			));
+
+		given(companionRepository.findAllById(request.getCompanionIds()))
+			.willReturn(List.of(
+				Companion.builder().id(11L).build(),
+				Companion.builder().id(12L).build()
+			));
+	}
+
+	private void verifyRepositoriesDeletion(Long userId) {
+		// 카테고리 정보 삭제 확인
+		verify(userCategoryRepository).deleteByUserId(userId);
+		verify(userCompanionRepository).deleteByUserId(userId);
+		verify(userMoodRepository).deleteByUserId(userId);
+		verify(userPriorityRepository).deleteByUserId(userId);
+	}
+
+	private void verifyRepositoriesSave() {
+		// 새로운 정보 저장 여부 확인
+		verify(userCategoryRepository).saveAll(anyList());
+		verify(userCompanionRepository).saveAll(anyList());
+		verify(userMoodRepository).saveAll(anyList());
+		verify(userPriorityRepository).saveAll(anyList());
 	}
 
 	User createNoProfileUser() {


### PR DESCRIPTION
<!-- 각 항목들은 항목에 관한 내용이 있을 때 사용하시면 됩니다.
없는 경우, "없습니다"라는 말 보다는 가급적이면 비워주세요.
 -->

# 요약

프로필 수정 api를 구현한다.

<!-- 무엇을 구현하였는지 요약해주세요. -->

# 작업 내용

<!-- 기능을 Commit 별로 잘개 쪼개고,가급적 Commit 별로 설명해주세요 -->
<!-- commit 번호는 명시하지 않아도 됩니다.  -->

- [x] [feat: 매핑 테이블에 인덱스 추가](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/4fcd4a7570c4df68e51a138a89c0c16fdbe5e8a3)
- [x] [feat: 프로필 정보 수정 api 구현](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/262ca11c796b259fd5174860ae306f789099f95a)
- [x] [test: 테스트 작성](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/9f9206986b3907935e52921d35f832254b76ef13)
- [x] [fix: 프로필 생성 여러번 호출하면, 값이 여러 개 저장되는 에러 수정](https://github.com/dnd-side-project/dnd-11th-5-backend/commit/bdbe1d92dec70c9225462c10d8a8c882695ef6d8)

# 기타 (논의하고 싶은 부분)

# 타 직군 전달 사항

close #177
